### PR TITLE
Incremental downloading

### DIFF
--- a/app/controllers/Versions.scala
+++ b/app/controllers/Versions.scala
@@ -27,8 +27,8 @@ class Versions(val config: RestorerConfig, s3Helper: S3, override val wsClient: 
     val snapshots = s3Helper.listForId(contentId)
     val snapshotsWithMetadata = snapshots.map { snapshotId =>
       val identifier = Json.toJson(snapshotId).asInstanceOf[JsObject]
-      val info = s3Helper.getSnapshotInfo(snapshotId).right.map(_.asInstanceOf[JsObject])
-      info.fold(_ => identifier, json => identifier ++ json)
+      val info: JsValue = s3Helper.getSnapshotInfo(snapshotId).right.toOption.getOrElse(JsObject(Nil))
+      identifier ++ Json.obj("info" -> info)
     }
     Ok(Json.toJson(snapshotsWithMetadata))
   }

--- a/app/controllers/Versions.scala
+++ b/app/controllers/Versions.scala
@@ -2,30 +2,35 @@ package controllers
 
 import config.RestorerConfig
 import helpers.Loggable
-import models.{SnapshotId, Version, VersionCount}
+import models.{SnapshotId, VersionCount}
 import play.api.libs.json._
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 import s3.S3
 
-import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.language.postfixOps
 
 class Versions(val config: RestorerConfig, s3Helper: S3, override val wsClient: WSClient)
   extends Controller with PanDomainAuthActions with Loggable {
   // Show a specific version
   def show(contentId: String, timestamp: String) = AuthAction {
     val snapshot = s3Helper.getRawSnapshot(SnapshotId(contentId, timestamp))
-    Ok(snapshot).as(JSON)
+    snapshot match {
+      case Right(ss) => Ok(ss).as(JSON)
+      case Left(error) => NotFound(error)
+    }
   }
 
-  def versions(contentId: String) = AuthAction {
-    logger.info(s"Getting JSON versions for $contentId")
+  def versionList(contentId: String) = AuthAction {
     val snapshots = s3Helper.listForId(contentId)
-    val versions = snapshots.map{ s =>
-      Version(s.timestamp, Json.parse(s3Helper.getRawSnapshot(s)))
+    val snapshotsWithMetadata = snapshots.map { snapshotId =>
+      val identifier = Json.toJson(snapshotId).asInstanceOf[JsObject]
+      val info = s3Helper.getSnapshotInfo(snapshotId).right.map(_.asInstanceOf[JsObject])
+      info.fold(_ => identifier, json => identifier ++ json)
     }
-    Ok(Json.toJson(versions))
+    Ok(Json.toJson(snapshotsWithMetadata))
   }
 
   def availableVersionsCount(contentId: String) = AuthAction {

--- a/app/models/Snapshot.scala
+++ b/app/models/Snapshot.scala
@@ -1,8 +1,5 @@
 package models
 
-import play.api.libs.json.{JsValue, Json}
+import play.api.libs.json.JsValue
 
-case class Snapshot(data: JsValue, metadata: SnapshotMetadata)
-object Snapshot {
-  implicit val formats = Json.format[Snapshot]
-}
+case class Snapshot(id: SnapshotId, data: JsValue)

--- a/app/models/SnapshotId.scala
+++ b/app/models/SnapshotId.scala
@@ -1,14 +1,19 @@
 package models
 
+import play.api.libs.json.Json
+
 case class SnapshotId(contentId: String, timestamp: String) {
   lazy val key = s"$contentId/$timestamp.json"
-  override def toString = key
+  lazy val infoKey = s"$contentId/$timestamp.info.json"
 }
+
 object SnapshotId {
-  private val SnapshotRegEx = """([0-9a-f]{24})/(.*).json""".r
+  private val SnapshotRegEx = """([0-9a-f]{24})/(.*?).(info.)?json""".r
 
   def fromKey: String => Option[SnapshotId] = {
-    case SnapshotRegEx(contentId, timestamp) => Some(SnapshotId(contentId, timestamp))
+    case SnapshotRegEx(contentId, timestamp, _) => Some(SnapshotId(contentId, timestamp))
     case _ => None
   }
+
+  implicit val formats = Json.format[SnapshotId]
 }

--- a/app/s3/S3.scala
+++ b/app/s3/S3.scala
@@ -9,6 +9,7 @@ import play.api.libs.json.{JsValue, Json}
 
 import scala.collection.JavaConverters._
 import scala.io.Source
+import scala.util.control.NonFatal
 
 class S3(config: RestorerConfig, s3Client: AmazonS3Client) extends Loggable {
   lazy val snapshotBucket: String = config.snapshotBucket
@@ -32,6 +33,9 @@ class S3(config: RestorerConfig, s3Client: AmazonS3Client) extends Loggable {
     } catch {
       case e:AmazonS3Exception if e.getErrorCode == "NoSuchKey" =>
         Left("Object doesn't exist")
+      case NonFatal(e) =>
+        logger.warn("Unexpected error whilst getting object", e)
+        Left(s"Couldn't retrieve object: ${e.getMessage}")
     }
   }
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ version := "1.0.0"
 
 scalaVersion in ThisBuild := "2.11.8"
 
+scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Xfatal-warnings")
+
 val awsSdkVersion = "1.11.5"
 
 libraryDependencies ++= Seq(

--- a/conf/routes
+++ b/conf/routes
@@ -18,7 +18,8 @@ GET            /management/healthcheck                     controllers.Managemen
 GET            /management/info                            controllers.Management.info
 
 # API
-GET           /api/1/versions/:contentId                   controllers.Versions.versions(contentId: String)
+GET           /api/1/versionList/:contentId                controllers.Versions.versionList(contentId: String)
+GET           /api/1/version/:contentId/:timestamp                controllers.Versions.show(contentId: String, timestamp: String)
 GET           /api/1/user                                  controllers.Login.user
 GET           /api/1/user/permissions                      controllers.Login.permissions
 GET           /api/1/version-count/:contentId              controllers.Versions.availableVersionsCount(contentId: String)

--- a/public/javascripts/app/collections/SnapshotIdModels.js
+++ b/public/javascripts/app/collections/SnapshotIdModels.js
@@ -1,0 +1,59 @@
+import angular from 'angular';
+import SnapshotIdModel from '../models/SnapshotIdModel';
+import SnapshotCollectionMod from '../services/SnapshotCollectionService';
+import BaseCollection from 'composer-components/lib/collections/BaseCollection';
+
+let listCache = {};
+
+var SnapshotIdModelsMod = angular.module('SnapshotIdModelsMod', ['SnapshotServiceMod']);
+
+SnapshotIdModelsMod.factory('SnapshotIdModels', [
+    '$q',
+    'SnapshotService',
+    'SnapshotIdModel',
+    function($q, SnapshotService, SnapshotIdModel){
+
+        class SnapshotIds extends BaseCollection {
+            constructor(models){
+                super();
+                this.models = models.map((snapshot) => new SnapshotIdModel.getModel(snapshot)).sort(this.comparator);
+            }
+
+            comparator(modelA, modelB){
+                return modelA.get('createdDate').isBefore(modelB.get('createdDate')) ? 1 : -1;
+            }
+        }
+
+        return {
+            getCollection: (id) => {
+                return $q((resolve, reject)=>{
+
+                    //resolve with cache if we already have the collection
+                    //this also results in collections being singletons within the application
+                    if (listCache[id]) {
+                        resolve(listCache[id]);
+                        //short circuit out of the function so we dont perform the AJAX request
+                        return;
+                    }
+
+                    //get the data from the server and build the new collections
+                    SnapshotService
+                        .getList(id)
+                        .success(function(data, status, header, config){
+                            if (data.length === 0) {
+                                reject(new Error('There are no snapshots available for this piece of content'));
+                                return;
+                            }
+                            listCache[id] = new SnapshotIds(data);
+                            resolve(listCache[id]);
+                        })
+                        .error(function(data, status, header, config){
+                            reject(data)
+                        });
+                })
+            }
+        }
+    }
+]);
+
+export default SnapshotIdModelsMod;

--- a/public/javascripts/app/collections/SnapshotIdModels.js
+++ b/public/javascripts/app/collections/SnapshotIdModels.js
@@ -40,7 +40,7 @@ SnapshotIdModelsMod.factory('SnapshotIdModels', [
                     SnapshotService
                         .getList(id)
                         .success(function(data, status, header, config){
-                            if (data.length === 0) {
+                            if (!Array.isArray(data) || data.length === 0) {
                                 reject(new Error('There are no snapshots available for this piece of content'));
                                 return;
                             }

--- a/public/javascripts/app/collections/SnapshotModels.js
+++ b/public/javascripts/app/collections/SnapshotModels.js
@@ -1,9 +1,8 @@
 import angular from 'angular';
 import SnapshotModel from '../models/SnapshotModel';
 import SnapshotCollectionMod from '../services/SnapshotCollectionService';
-import BaseCollection from 'composer-components/lib/collections/BaseCollection';
 
-let cache = {};
+let contentCache = {};
 
 var SnapshotModelsMod = angular.module('SnapshotModelsMod', ['SnapshotServiceMod']);
 
@@ -13,39 +12,26 @@ SnapshotModelsMod.factory('SnapshotModels', [
   'SnapshotModel',
   function($q, SnapshotService, SnapshotModel){
 
-    class SnapshotModels extends BaseCollection {
-      constructor(models){
-        super();
-        this.models = models.map((model) => new SnapshotModel.getModel(model)).sort(this.comparator);
-      }
-
-      comparator(modelA, modelB){
-        return modelA.get('createdDate').isBefore(modelB.get('createdDate')) ? 1 : -1;
-      }
-    }
-
     return {
-      getCollection: (id) => {
+      getSnapshot: (contentId, timestamp) => {
         return $q((resolve, reject)=>{
+
+          var key = `${contentId}/${timestamp}`;
 
           //resolve with cache if we already have the collection
           //this also results in collections being singletons within the application
-          if (cache[id]) {
-            resolve(cache[id]);
+          if (contentCache[key]) {
+            resolve(contentCache[key]);
             //short circuit out of the function so we dont perform the AJAX request
             return;
           }
 
           //get the data from the server and build the new collections
           SnapshotService
-              .get(id)
+              .getSnapshot(contentId, timestamp)
               .success(function(data, status, header, config){
-                if (data.length === 0) {
-                  reject(new Error('There are no snapshots available for this piece of content'));
-                  return;
-                }
-                cache[id] = new SnapshotModels(data);
-                resolve(cache[id]);
+                  contentCache[key] = new SnapshotModel.getModel(timestamp, data);
+                resolve(contentCache[key]);
               })
               .error(function(data, status, header, config){
                 reject(data)

--- a/public/javascripts/app/collections/index.js
+++ b/public/javascripts/app/collections/index.js
@@ -1,8 +1,10 @@
 import angular from 'angular';
 import SnapshotModels from './SnapshotModels';
+import SnapshotIdModels from './SnapshotIdModels';
 
 var collections = angular.module('restorerCollections', [
-  'SnapshotModelsMod'
+  'SnapshotModelsMod',
+  'SnapshotIdModelsMod'
 ]);
 
 export default collections;

--- a/public/javascripts/app/controllers/SnapshotListCtrl.js
+++ b/public/javascripts/app/controllers/SnapshotListCtrl.js
@@ -1,5 +1,5 @@
 import angular from 'angular';
-import SnapshotModelsMod from '../collections/SnapshotModels';
+import SnapshotIdModelsMod from '../collections/SnapshotIdModels';
 import mediator from '../utils/mediator';
 
 var SnapshotListCtrlMod = angular.module('SnapshotListCtrlMod', []);
@@ -9,15 +9,15 @@ SnapshotListCtrlMod.controller('SnapshotListCtrl', [
   '$routeParams',
   '$timeout',
   'SnapshotService',
-  'SnapshotModels',
-  function($scope, $routeParams, $timeout, SnapshotService, SnapshotModels){
+  'SnapshotIdModels',
+  function($scope, $routeParams, $timeout, SnapshotService, SnapshotIdModels){
 
     var snapshotCollection;
 
     $scope.isLoading  = true;
     $scope.isSidebarActive = false;
 
-    SnapshotModels
+    SnapshotIdModels
       .getCollection($routeParams.contentId)
       .then((collection) => {
         snapshotCollection = collection;
@@ -27,11 +27,10 @@ SnapshotListCtrlMod.controller('SnapshotListCtrl', [
 
         var activeModel = collection.find((data)=> data.activeState);
         $scope.articleTitle = activeModel.getHeadline();
-        $scope.articleHash = activeModel.get('id');
+        $scope.articleHash = activeModel.getContentId();
         $scope.articleURL = [__COMPOSER_DOMAIN__, "content", $scope.articleHash].join("/");
         //animate sidebar in
         $timeout(()=> $scope.isSidebarActive = true, 500);
-
       })
       .catch((err) => {
         $scope.isLoading = false;
@@ -77,7 +76,9 @@ SnapshotListCtrlMod.controller('SnapshotListCtrl', [
       model.set('activeState', true);
       mediator.publish('mixpanel:view-snapshot', model);
       //place the content
-      $timeout(()=> mediator.publish('snapshot-list:display-content', model), 1);
+      $timeout(()=>
+          mediator.publish('snapshot-list:load-content', model.getContentId(), model.getTimestamp()), 10
+      );
     }
 
   }

--- a/public/javascripts/app/models/SnapshotIdModel.js
+++ b/public/javascripts/app/models/SnapshotIdModel.js
@@ -1,0 +1,107 @@
+import angular  from 'angular';
+import moment   from 'moment';
+import lodash_get from 'lodash.get';
+import BaseModel from 'composer-components/lib/models/BaseModel';
+
+var SnapshotIdModelMod = angular.module('SnapshotIdModelMod', []);
+
+SnapshotIdModelMod.factory('SnapshotIdModel', [
+    function(){
+
+        class SnapshotIdModel extends BaseModel{
+            constructor(data){
+                super();
+                // contentId: String, timestamp: String
+                var contentId = data.contentId;
+                var timestamp = data.timestamp;
+                var metadata = data.metadata;
+                var summary = data.summary;
+                this.data = {
+                    timestamp: timestamp,
+                    contentId: contentId,
+                    createdDate: moment(timestamp),
+                    activeState: false,
+                    metadata: metadata,
+                    summary: summary
+                };
+            }
+
+            getCreatedDate(){
+                return this.get('createdDate').format('HH:mm:ss D MMMM YYYY');
+            }
+
+            getContentId() {
+                return this.get('contentId')
+            }
+
+            getTimestamp() {
+                return this.get('timestamp')
+            }
+
+            getHeadline() {
+                return this.get('summary.preview.fields.headline')
+            }
+
+            getSnapshotReason() {
+                return this.get('metadata.reason')
+            }
+
+            isLegallySensitive() {
+                const legallySensitive = this.get('summary.preview.settings.legallySensitive');
+                return legallySensitive === "true";
+            }
+
+            commentsEnabled() {
+                const commentable = this.get('summary.preview.settings.commentable');
+
+                let ret = {
+                    defined: commentable,
+                    on: (commentable === "true")
+                };
+
+                return ret;
+            }
+
+            getPublishedState() {
+                const publishedDetails = this.get('summary.contentChangeDetails.published');
+                const published = this.get('summary.published');
+                const settings = this.get('summary.preview.settings');
+                const scheduledLaunchDate = this.get('summary.scheduledLaunchDate');
+
+                if (!!scheduledLaunchDate) {
+                    const time = moment(scheduledLaunchDate);
+                    return "Scheduled  " + time.format("ddd D MMMM YYYY");
+                }
+
+                if (!!settings && !!settings.embargoedUntil) {
+                    const time = moment(settings.embargoedUntil);
+                    return "Embargoed until " + time.format("ddd D MMMM YYYY");
+                }
+
+                if (published) {
+                    return 'Published';
+                }
+
+                if (!published && !!publishedDetails) {
+                    return "Taken down";
+                }
+
+            }
+
+            getRelativeDate(date = moment()){
+                return this.get('createdDate').from(date, true);
+            }
+
+            get(key){
+                return lodash_get(this.data, key);
+            }
+        }
+
+
+        return {
+            getModel: (data)=> new SnapshotIdModel(data)
+        }
+    }
+]);
+
+export default SnapshotIdModelMod;

--- a/public/javascripts/app/models/SnapshotIdModel.js
+++ b/public/javascripts/app/models/SnapshotIdModel.js
@@ -14,8 +14,8 @@ SnapshotIdModelMod.factory('SnapshotIdModel', [
                 // contentId: String, timestamp: String
                 var contentId = data.contentId;
                 var timestamp = data.timestamp;
-                var metadata = data.metadata;
-                var summary = data.summary;
+                var metadata = data.info.metadata;
+                var summary = data.info.summary;
                 this.data = {
                     timestamp: timestamp,
                     contentId: contentId,

--- a/public/javascripts/app/models/SnapshotIdModel.js
+++ b/public/javascripts/app/models/SnapshotIdModel.js
@@ -86,6 +86,7 @@ SnapshotIdModelMod.factory('SnapshotIdModel', [
                     return "Taken down";
                 }
 
+                return "";
             }
 
             getRelativeDate(date = moment()){

--- a/public/javascripts/app/models/SnapshotModel.js
+++ b/public/javascripts/app/models/SnapshotModel.js
@@ -10,51 +10,18 @@ SnapshotModelMod.factory('SnapshotModel', [
   function(){
 
     class SnapshotModel extends BaseModel{
-      constructor(data){
+      constructor(timestamp, snapshotData){
         super();
-        var timestamp = data.timestamp;
-        var snapshotData = data.snapshot;
         this.data = {
           timestamp: timestamp,
           createdDate: moment(timestamp),
           activeState: false,
-          snapshot: snapshotData.data,
-          metadata: snapshotData.metadata
+          snapshot: snapshotData
         };
       }
 
       getCreatedDate(){
         return this.get('createdDate').format('HH:mm:ss D MMMM YYYY');
-      }
-
-      isPublished() {
-          return this.get('snapshot.published');
-      }
-
-      getPublishedState() {
-          const publishedDetails = this.get('snapshot.contentChangeDetails.published');
-          const published = this.get('snapshot.published');
-          const settings = this.get('snapshot.preview.settings');
-          const scheduledLaunchDate = this.get('snapshot.scheduledLaunchDate');
-
-          if (!!scheduledLaunchDate) {
-              const time = moment(scheduledLaunchDate);
-              return "Scheduled  " + time.format("ddd D MMMM YYYY");
-          }
-
-          if (!!settings && !!settings.embargoedUntil) {
-              const time = moment(settings.embargoedUntil);
-              return "Embargoed until " + time.format("ddd D MMMM YYYY");
-          }
-
-          if (published) {
-              return 'Published';
-          }
-
-          if (!published && !!publishedDetails) {
-              return "Taken down";
-          }
-
       }
 
       getHeadline() {
@@ -63,42 +30,6 @@ SnapshotModelMod.factory('SnapshotModel', [
 
       getStandfirst() {
           return this.get("snapshot.preview.fields.standfirst");
-      }
-
-      getSettingsInfo() {
-          const settings = this.get('snapshot.preview.settings');
-          // flex stores strings not booleans so we need to convert
-          // them all over
-          const type = this.get('snapshot.type');
-          const liveBloggingNow = (settings.liveBloggingNow === "true");
-          const isLive = (type === "liveblog") && liveBloggingNow;
-
-          const retSettings = {
-              isLive: isLive,
-              type: type
-          };
-
-          return retSettings;
-      }
-
-      isLegallySensitive() {
-          const legallySensitive = this.get('snapshot.preview.settings.legallySensitive');
-          return legallySensitive === "true";
-      }
-
-      commentsEnabled() {
-          const commentable = this.get('snapshot.preview.settings.commentable');
-
-          let ret = {
-              defined: commentable,
-              on: (commentable === "true")
-          };
-
-          return ret;
-      }
-
-      getRelativeDate(date = moment()){
-        return this.get('createdDate').from(date, true);
       }
 
       getHTMLContent(){
@@ -129,6 +60,7 @@ SnapshotModelMod.factory('SnapshotModel', [
         delete clone.timestamp;
         delete clone.createdDate;
         delete clone.activeState;
+        delete clone.snapshot;
         return clone;
       }
 
@@ -139,7 +71,7 @@ SnapshotModelMod.factory('SnapshotModel', [
 
 
     return {
-      getModel: (data)=> new SnapshotModel(data)
+      getModel: (timestamp, data)=> new SnapshotModel(timestamp, data)
     }
   }
 ]);

--- a/public/javascripts/app/models/index.js
+++ b/public/javascripts/app/models/index.js
@@ -1,8 +1,10 @@
 import angular from 'angular';
 import SnapshotModelMod from './SnapshotModel';
+import SnapshotIdModelMod from './SnapshotIdModel';
 
 var models = angular.module('restorerModels', [
-  'SnapshotModelMod'
+  'SnapshotModelMod',
+  'SnapshotIdModelMod'
 ]);
 
 export default models;

--- a/public/javascripts/app/services/RestoreService.js
+++ b/public/javascripts/app/services/RestoreService.js
@@ -7,22 +7,22 @@ var RestoreService = RestoreServiceMod.service('RestoreService', [
   '$http',
   '$routeParams',
   '$q',
-  'SnapshotModels',
-  function($http, $routeParams, $q, SnapshotModels){
+  'SnapshotIdModels',
+  function($http, $routeParams, $q, SnapshotIdModels){
 
     return {
       restore: () => {
         var contentId = $routeParams.contentId;
         return $q((resolve, reject) => {
           //get collection
-          SnapshotModels.getCollection(contentId)
+          SnapshotIdModels.getCollection(contentId)
             .then((collection) => {
               //get model
               var model = collection.find((data) => data.activeState);
               mediator.publish('mixpanel:restore-snapshot', model);
               //make the request
               $http({
-                url: `/api/1/restore/${contentId}/${model.get('timestamp')}`,
+                url: `/api/1/restore/${contentId}/${model.getTimestamp()}`,
                 method: 'POST'
               })
               .success((data)=> resolve(data))

--- a/public/javascripts/app/services/SnapshotCollectionService.js
+++ b/public/javascripts/app/services/SnapshotCollectionService.js
@@ -6,7 +6,9 @@ SnapshotServiceMod.service('SnapshotService', [
   '$http',
   function($http){
     return {
-      get: (id) => $http.get(`/api/1/versions/${id}`)
+      get: (id) => $http.get(`/api/1/versions/${id}`),
+      getList: (id) => $http.get(`/api/1/versionList/${id}`),
+      getSnapshot: (contentId, timestamp) => $http.get(`/api/1/version/${contentId}/${timestamp}`)
     }
   }
 ]);

--- a/public/javascripts/app/templates/restore-list.html
+++ b/public/javascripts/app/templates/restore-list.html
@@ -59,8 +59,10 @@
                 <div class="snapshot-list__item__content"
                      ng-class="{ 'active': model.get('activeState') && isDisplayingHTML }"
                      ng-click="ctrl.onItemClicked($index)">
+                    <h6 class="snapshot-list__item__content__relative-date">{{ model.getSnapshotReason() }}</h6>
                     <h6 class="snapshot-list__item__content__actual-date">{{ model.getCreatedDate() }}</h6>
                     <h6 class="snapshot-list__item__content__relative-date">{{ model.getRelativeDate() }} ago</h6>
+
                 </div>
                 <div class="snapshot-list__item__information">
                     <div class="snapshot-list__item__status"

--- a/test/scala/models/SnapshotIdSpec.scala
+++ b/test/scala/models/SnapshotIdSpec.scala
@@ -1,0 +1,16 @@
+package scala.models
+
+import models.SnapshotId
+import org.scalatest.{FlatSpec, ShouldMatchers}
+
+class SnapshotIdSpec extends FlatSpec with ShouldMatchers {
+  "fromKey" should "extract the ID and timestamp from a key" in {
+    val key = "575ee43ee4b0625eba5110f6/2016-06-13T16:57:50.306Z.json"
+    SnapshotId.fromKey(key) should be(Some(SnapshotId("575ee43ee4b0625eba5110f6", "2016-06-13T16:57:50.306Z")))
+  }
+
+  it should "extract the ID and timestamp from an info key" in {
+    val key = "575ee43ee4b0625eba5110f6/2016-06-13T16:57:50.306Z.info.json"
+    SnapshotId.fromKey(key) should be(Some(SnapshotId("575ee43ee4b0625eba5110f6", "2016-06-13T16:57:50.306Z")))
+  }
+}


### PR DESCRIPTION
Previously restorer would download all the snapshots stored for a piece of content. This PR changes the approach so that only summary data is downloaded and the snapshot is downloaded only when a piece of content is selected.

There are related changes to snapshotter to provide the summary file here: https://github.com/guardian/flexible-snapshotter/pull/10.