### PR TITLE
Honour permissions in both backend and frontend

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -40,7 +40,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   val loginController = new Login(permissionsClient, restorerConfig, wsClient)
   val managementController = new Management(restorerConfig, wsClient)
   val versionsController = new Versions(restorerConfig, snapshotApi, wsClient)
-  val restoreController = new Restore(snapshotApi, flexibleApi, restorerConfig, wsClient)
+  val restoreController = new Restore(snapshotApi, flexibleApi, permissionsClient, restorerConfig, wsClient)
 
   def router: Router = new Routes(
     httpErrorHandler,

--- a/app/controllers/Restore.scala
+++ b/app/controllers/Restore.scala
@@ -7,6 +7,7 @@ import config.RestorerConfig
 import helpers.Loggable
 import logic.{FlexibleApi, SnapshotApi}
 import models._
+import permissions.Permissions
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.mvc.{Controller, Result}
@@ -17,24 +18,32 @@ import scala.concurrent.{Await, Future}
 import scala.language.postfixOps
 import scala.util.control.NonFatal
 
-class Restore(snapshotApi: SnapshotApi, flexibleApi: FlexibleApi, val config: RestorerConfig, val wsClient: WSClient)
-  extends Controller with PanDomainAuthActions with Loggable {
+class Restore(snapshotApi: SnapshotApi, flexibleApi: FlexibleApi, permissions: Permissions, val config: RestorerConfig,
+  val wsClient: WSClient) extends Controller with PanDomainAuthActions with Loggable {
 
   def userFromPandaUser(user: PandaUser) = User(user.firstName, user.lastName, user.email)
 
   def restore(sourceId: String, contentId: String, timestamp: String, destinationId: String) = AuthAction.async { request =>
-    val user = userFromPandaUser(request.user)
-    val sourceStack = config.stackFromId(sourceId)
-    val targetStack = config.stackFromId(destinationId)
-    val snapshotId = SnapshotId(contentId, timestamp)
-    val result = snapshotApi.getSnapshot(sourceStack.snapshotBucket, snapshotId).flatMap[Result] {
-      case None => Attempt.Right(NotFound)
-      case Some(snapshot) => flexibleApi.restore(targetStack, user, contentId, snapshot).map(Ok(_))
+    permissions.userPermissionMap(request.user).flatMap { permissionMap =>
+      if (!permissionMap(permissions.RestoreContent)) {
+        Future.successful(Forbidden(s"You do not have the ${permissions.RestoreContent.name} permission which is required to restore content"))
+      } else if (sourceId != destinationId && !permissionMap(permissions.RestoreContentToAlternateStack)) {
+        Future.successful(Forbidden(s"You do not have the ${permissions.RestoreContentToAlternateStack.name} permission which is required to restore content from one stack to another"))
+      } else {
+        val user = userFromPandaUser(request.user)
+        val sourceStack = config.stackFromId(sourceId)
+        val targetStack = config.stackFromId(destinationId)
+        val snapshotId = SnapshotId(contentId, timestamp)
+        val result = snapshotApi.getSnapshot(sourceStack.snapshotBucket, snapshotId).flatMap[Result] {
+          case None => Attempt.Right(NotFound)
+          case Some(snapshot) => flexibleApi.restore(targetStack, user, contentId, snapshot).map(Ok(_))
+        }
+        result.fold(
+          errors => InternalServerError(s"Error whilst restoring: $errors"),
+          identity
+        )
+      }
     }
-    result.fold(
-      errors => InternalServerError(s"Error whilst restoring: $errors"),
-      identity
-    )
   }
 
   def restoreDestinations(contentId: String) = AuthAction.async {

--- a/app/permissions/Permissions.scala
+++ b/app/permissions/Permissions.scala
@@ -1,12 +1,11 @@
 package permissions
 
 import com.amazonaws.auth.AWSCredentialsProvider
-import com.gu.editorial.permissions.client._
+import com.gu.editorial.permissions.client.{PermissionGranted, _}
 import com.gu.pandomainauth.model.User
 import config.RestorerConfig
 
-import scala.concurrent.Await
-import scala.concurrent.duration._
+import scala.concurrent.Future
 import scala.language.postfixOps
 
 /**
@@ -23,19 +22,22 @@ class Permissions(restorerConfig: RestorerConfig, credsProvider: AWSCredentialsP
       all = all,
       s3BucketPrefix = stage,
       awsCredentials = credsProvider
-
-
     )
   }
 
   val RestoreContent = Permission("restore_content", app, PermissionDenied)
 
-  val all = Seq(RestoreContent)
+  val RestoreContentToAlternateStack = Permission("restore_content_to_any_stack", app, PermissionDenied)
 
-  private val timeout = 2000 millis
+  val all = Seq(RestoreContent, RestoreContentToAlternateStack)
 
-  def hasAccess(user: User): Boolean = {
-    implicit val permsUser = PermissionsUser(user.email)
-    Await.result(getEither(RestoreContent).map(_.isRight), timeout)
+  def isGranted(user: User, permission: Permission): Future[Boolean] = {
+    get(permission)(PermissionsUser(user.email)).map {
+      case PermissionGranted => true
+      case _ => false
+    }
   }
+
+  def userPermissionMap(user: User): Future[Map[Permission, Boolean]] =
+    Future.sequence(all.map(p => isGranted(user, p).map(p ->))).map(_.toMap)
 }

--- a/public/javascripts/app/controllers/SnapshotContentCtrl.js
+++ b/public/javascripts/app/controllers/SnapshotContentCtrl.js
@@ -1,6 +1,5 @@
 import angular from 'angular';
 import mediator from '../utils/mediator';
-import SnapshotCollectionMod from '../collections/SnapshotIdModels';
 import safeApply from '../utils/safe-apply';
 
 var SnapshotContentCtrlMod = angular.module('SnapshotContentCtrlMod', []);
@@ -20,7 +19,7 @@ SnapshotContentCtrlMod.controller('SnapshotContentCtrl', [
     $scope.canRestore =  false;
 
     UserService.get().then((user) => {
-        if(user.permissions && user.permissions.restoreContent && user.permissions.restoreContent === true) {
+        if(user.permissions && user.permissions.restore_content && user.permissions.restore_content === true) {
           $scope.canRestore = true;
         }
     }).catch ((err) => {

--- a/public/javascripts/app/services/UserService.js
+++ b/public/javascripts/app/services/UserService.js
@@ -2,17 +2,36 @@ import angular from 'angular';
 
 var UserServiceMod = angular.module('UserServiceMod', []);
 
+let userData;
+
 UserServiceMod.service('UserService', [
   '$http',
-  function($http) {
+    '$q',
+  function($http, $q) {
     return {
       get: () => {
-        return $http.get('/api/1/user').then((userResponse) => {
-          return $http.get('/api/1/user/permissions').then((permissionsResponse) => {
-            userResponse.data["permissions"] = permissionsResponse.data;
-            return userResponse.data;
-          })
-        });
+        return $q((resolve, reject) => {
+            if (userData) {
+                resolve(userData);
+                return;
+            }
+
+            $http.get('/api/1/user').
+            then((userResponse) => {
+                $http.get('/api/1/user/permissions').
+                then((permissionsResponse) => {
+                    userResponse.data["permissions"] = permissionsResponse.data;
+                    userData = userResponse.data;
+                    resolve(userData);
+                }).
+                catch((data) => {
+                    reject(data);
+                });
+            }).
+            catch((data) =>
+                reject(data)
+            );
+        })
       }
     }
   }


### PR DESCRIPTION
Enforces the new permission @jennysivapalan created in https://github.com/guardian/permissions/pull/61.

This makes a backend change to enforce both permissions in the restore endpoint. It also filters the available destinations in the UI to those that can be restored too.