### PR TITLE
Older versions of Chrome don't support max-height: 100%

### DIFF
--- a/public/sass/components/snapshot-content.scss
+++ b/public/sass/components/snapshot-content.scss
@@ -12,7 +12,7 @@
   overflow: hidden;
   display: flex;
   flex-flow: column;
-  max-height: 100%;
+  max-height: calc(100vh - 46px);
 }
 
 .snapshot-content__container {


### PR DESCRIPTION
This meant that users were unable to scroll down the content pane in restorer. This fixes it by falling back to a viewport height calculation.