### PR TITLE
Change the way we load SVGs to improve load speed

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
       "moment": "npm:moment@^2.10.2",
       "necolas/normalize.css": "npm:normalize.css@3.0.2",
       "normalize.css": "npm:normalize.css@^3.0.3",
-      "svg": "github:cutandpastey/plugin-svg@^0.2.0",
-      "systemjs-plugin-css": "npm:systemjs-plugin-css@^0.1.20"
+      "systemjs-plugin-css": "npm:systemjs-plugin-css@^0.1.20",
+      "text": "github:systemjs/plugin-text@0.0.2"
     },
     "devDependencies": {
       "babel": "npm:babel@^4.7.16",

--- a/public/config.js
+++ b/public/config.js
@@ -26,8 +26,8 @@ System.config({
     "moment": "npm:moment@2.10.2",
     "necolas/normalize.css": "npm:normalize.css@3.0.2",
     "normalize.css": "npm:normalize.css@3.0.3",
-    "svg": "github:cutandpastey/plugin-svg@0.2.0",
     "systemjs-plugin-css": "npm:systemjs-plugin-css@0.1.20",
+    "text": "github:systemjs/plugin-text@0.0.2",
     "traceur": "github:jmcriffey/bower-traceur@0.0.93",
     "traceur-runtime": "github:jmcriffey/bower-traceur-runtime@0.0.93",
     "github:angular/bower-angular-route@1.3.15": {

--- a/public/javascripts/app/lib/icons/index.js
+++ b/public/javascripts/app/lib/icons/index.js
@@ -1,42 +1,42 @@
 import angular from 'angular'
 
-import clockActive      from './svg/clock-active.svg!';
-import clockDisabled    from './svg/clock-disabled.svg!';
-import infoActive       from './svg/info-active.svg!';
-import infoDisabled     from './svg/info-disabled.svg!';
-import publishActive    from './svg/publish-active.svg!';
-import publishDisabled  from './svg/publish-disabled.svg!';
-import previewActive    from './svg/preview-active.svg!';
-import arrowDown        from './svg/arrow-down.svg!';
-import composerIcon     from './svg/composer-icon.svg!';
-import wrenchActive     from './svg/wrench-active.svg!';
-import wrenchDisabled   from './svg/wrench-disabled.svg!';
-import expandActive     from './svg/expand-active.svg!';
-import expandDisabled   from './svg/expand-disabled.svg!';
+import clockActive      from './svg/clock-active.svg!text';
+import clockDisabled    from './svg/clock-disabled.svg!text';
+import infoActive       from './svg/info-active.svg!text';
+import infoDisabled     from './svg/info-disabled.svg!text';
+import publishActive    from './svg/publish-active.svg!text';
+import publishDisabled  from './svg/publish-disabled.svg!text';
+import previewActive    from './svg/preview-active.svg!text';
+import arrowDown        from './svg/arrow-down.svg!text';
+import composerIcon     from './svg/composer-icon.svg!text';
+import wrenchActive     from './svg/wrench-active.svg!text';
+import wrenchDisabled   from './svg/wrench-disabled.svg!text';
+import expandActive     from './svg/expand-active.svg!text';
+import expandDisabled   from './svg/expand-disabled.svg!text';
 
 var templates = {
-  'clock-active'      : clockActive,
-  'clock-disabled'    : clockDisabled,
-  'info-active'       : infoActive,
-  'info-disabled'     : infoDisabled,
-  'publish-active'    : publishActive,
-  'publish-disabled'  : publishDisabled,
-  'preview-active'    : previewActive,
-  'arrow-down'        : arrowDown,
-  'composer-icon'     : composerIcon,
-  'wrench-active'     : wrenchActive,
-  'wrench-disabled'   : wrenchDisabled,
-  'expand-active'     : expandActive,
-  'expand-disabled'   : expandDisabled
-}
+    'clock-active': clockActive,
+    'clock-disabled': clockDisabled,
+    'info-active': infoActive,
+    'info-disabled': infoDisabled,
+    'publish-active': publishActive,
+    'publish-disabled': publishDisabled,
+    'preview-active': previewActive,
+    'arrow-down': arrowDown,
+    'composer-icon': composerIcon,
+    'wrench-active': wrenchActive,
+    'wrench-disabled': wrenchDisabled,
+    'expand-active': expandActive,
+    'expand-disabled': expandDisabled
+};
 
 var icons = angular.module('guIcons', []);
 
-icons.directive('guIcon', function icons(){
-  return {
-    restrict: 'E',
-    template: (el, attrs) => templates[attrs.variant].outerHTML
-  };
+icons.directive('guIcon', function icons() {
+    return {
+        restrict: 'E',
+        template: (el, attrs) => templates[attrs.variant]
+    }
 });
 
 export default icons;


### PR DESCRIPTION
Prior to this change the expand-disabled.svg was downloaded N times (where N is the number of snapshots available) without any caching (due to the SVG plugin that we were using).

This bundles causes the assets to be loaded only once each - and will hopefully bundle them as well. 

Empirically this has vastly improved performance.