### PR TITLE
Destination binding in ng-repeat should be bound to parent scope

### DIFF
--- a/app/views/main.scala.html
+++ b/app/views/main.scala.html
@@ -5,7 +5,6 @@
 <head lang="en">
     <meta charset="UTF-8">
     <title>Composer Restorer - @pageTitle</title>
-    <link rel="stylesheet" type="text/css" href="@routes.Assets.at("jspm_packages/github/necolas/normalize.css@3.0.2/normalize.css")" />
     <link rel="stylesheet" type="text/css" href="@routes.Assets.at("jspm_packages/github/guardian/scribe-plugin-noting@0.3.29/skins/gu-noting.css")" />
     <link rel="stylesheet" type="text/css" href="@routes.Assets.at("css/index.css")" />
     <link rel="shortcut icon" type="image/png" href="@routes.Assets.at("images/fav-versions-32.png")" />

--- a/public/javascripts/app/templates/restore-list.html
+++ b/public/javascripts/app/templates/restore-list.html
@@ -223,7 +223,7 @@
                                                                id="{{dest.systemId}}"
                                                                name="destination"
                                                                ng-disabled="!dest.available"
-                                                               ng-model="selectedDestination"
+                                                               ng-model="$parent.selectedDestination"
                                                                ng-value="dest"/>
                                                         <span class="checked-decal"></span>
                                                         <span>{{dest.displayName}} <em ng-bind-html="dest.changeString"></em></span>

--- a/public/javascripts/app/templates/restore-list.html
+++ b/public/javascripts/app/templates/restore-list.html
@@ -186,7 +186,7 @@
          ng-controller="ModalCtrl as modalCtrl"
          ng-class="{ 'visually-hidden': !isActive }">
         <gu-box class="modal__content" variant="primary">
-            <form novalidate class="modal-form" ng-controller="RestoreFormCtrl as formCtrl">
+            <form novalidate class="modal-form" ng-controller="RestoreFormCtrl as formCtrl" ng-submit="formCtrl.restore()">
                 <div class="modal__content__track">
                     <gu-row>
                         <gu-column ng-class="{ 'in-active': isLoading }" class="form-panel" span="6">
@@ -262,8 +262,7 @@
                             <!-- ACTIONS -->
                             <gu-row variant="reverse" class="modal__content__container">
                                 <gu-btn variant="active" class="modal__content__btn" type="submit"
-                                        ng-disabled="!selfInContent || !elseInContent"
-                                        ng-click="formCtrl.restore()">
+                                        ng-disabled="!selfInContent || !elseInContent">
                                     <gu-icon variant="wrench-disabled"></gu-icon>
                                     Restore Version
                                 </gu-btn>


### PR DESCRIPTION
`ng-repeat` creates a new scope for each element it creates - in order to bind to a controller level scope variable we must use `$parent` - otherwise updates will be bound to a variable in the child scope and not take effect.

Slightly puzzled how this ever worked.

Also pick up a couple of other tweaks - one is to remove the reference to a no longer existing CSS file that was causing red in the console. The other is to move the restore action back to an `ng-submit` directive so it works with more than just mouse clicks (originally changed as an earlier design had multiple 'submit' buttons).