### PR TITLE
Secret config setup

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -8,7 +8,7 @@
 # This must be changed for production, but we recommend not changing it in this file.
 #
 # See http://www.playframework.com/documentation/latest/ApplicationSecret for more details.
-application.secret="changeme"
+play.crypto.secret="changeme"
 
 # The application languages
 # ~~~~~

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -8,7 +8,7 @@
 # This must be changed for production, but we recommend not changing it in this file.
 #
 # See http://www.playframework.com/documentation/latest/ApplicationSecret for more details.
-application.secret="HOk5NiVO_0K1IexkKA?Hc7vhwTUNQ2VGa@^dBIateCnGiV?U?H>awt3?D2WdA5kB"
+application.secret="changeme"
 
 # The application languages
 # ~~~~~
@@ -16,9 +16,7 @@ application.langs="en"
 
 play.application.loader = AppLoader
 
-logging.stream=elk-PROD-KinesisStream-1PYU4KS1UEQA
-
 logger-startup-timeout = 30s
 
 # Environment specific settings
-include "local.conf"
+include file("/home/ubuntu/application.secrets.conf")


### PR DESCRIPTION
Restorer hasn't got a solution for secret config, which is pretty sad. The only way to set the application secret in play is via a config file, so this change includes a config file in the application.conf, which will be available on the EC2 boxes - https://github.com/guardian/editorial-tools-platform/pull/97