### PR TITLE
Restore content via flex api proxy rather than directly to the api.

### DIFF
--- a/app/models/FlexibleStack.scala
+++ b/app/models/FlexibleStack.scala
@@ -23,7 +23,7 @@ object FlexibleStack {
     val suffix = if (isSecondary) secondarySuffix else ""
 
     val displayName = s"Composer$suffix ($stage)"
-    val apiPrefix = s"http://api.$stage.$stack.gudiscovery.:8080"
+    val apiPrefix = s"http://flexible-content-api-proxy.$stage.$stack.gudiscovery.:8080"
     val composerPrefix = s"https://composer$suffix.$domain"
     val snapshotBucket = s"$stack-snapshotter-${stage.toLowerCase}"
 


### PR DESCRIPTION
This will ensure that APIV2 (postgres) remains up to date after a restore is made