### PR TITLE
Bump up to Scala 2.12.3

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -25,7 +25,7 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
 
   val restorerConfig = new RestorerConfig(configuration)
 
-  def panDomainSettings: PanDomainAuthSettingsRefresher = new PanDomainAuthSettingsRefresher(
+  val panDomainSettings: PanDomainAuthSettingsRefresher = new PanDomainAuthSettingsRefresher(
     domain = restorerConfig.domain,
     system = "restorer",
     awsCredentialsProvider = restorerConfig.creds,

--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -1,6 +1,7 @@
-import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.gu.editorial.permissions.client.PermissionsConfig
+import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import config.RestorerConfig
 import controllers._
 import helpers.{HSTSFilter, LogStash, Loggable}
@@ -24,10 +25,17 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
 
   val restorerConfig = new RestorerConfig(configuration)
 
+  def panDomainSettings: PanDomainAuthSettingsRefresher = new PanDomainAuthSettingsRefresher(
+    domain = restorerConfig.domain,
+    system = "restorer",
+    awsCredentialsProvider = restorerConfig.creds,
+    actorSystem = actorSystem
+  )
+
   if (context.environment.mode == Mode.Prod) restorerConfig.loggingConfig.foreach(LogStash.init)
 
-  val region: Region = Region getRegion Regions.fromName(configuration.getOptional[String]("aws.region") getOrElse "eu-west-1")
-  val s3Client: AmazonS3Client = new AmazonS3Client(restorerConfig.creds).withRegion(region)
+  val region: Regions = Regions.fromName(configuration.getOptional[String]("aws.region") getOrElse "eu-west-1")
+  val s3Client: AmazonS3 = AmazonS3ClientBuilder.standard().withCredentials(restorerConfig.creds).withRegion(region).build()
 
   val permissionsClient = new Permissions(restorerConfig, restorerConfig.creds)
   val permissionsConfig: PermissionsConfig = permissionsClient.config
@@ -36,11 +44,11 @@ class AppComponents(context: Context) extends BuiltInComponentsFromContext(conte
   val snapshotApi = new SnapshotApi(s3Client)
   val flexibleApi = new FlexibleApi(wsClient)
 
-  val applicationController = new Application(controllerComponents, restorerConfig, wsClient)
-  val loginController = new Login(controllerComponents, permissionsClient, restorerConfig, wsClient)
-  val managementController = new Management(controllerComponents, restorerConfig, wsClient)
-  val versionsController = new Versions(controllerComponents, restorerConfig, snapshotApi, wsClient)
-  val restoreController = new Restore(controllerComponents, snapshotApi, flexibleApi, permissionsClient, restorerConfig, wsClient)
+  val applicationController = new Application(controllerComponents, restorerConfig, wsClient, panDomainSettings)
+  val loginController = new Login(controllerComponents, permissionsClient, restorerConfig, wsClient, panDomainSettings)
+  val managementController = new Management(controllerComponents, restorerConfig, wsClient, panDomainSettings)
+  val versionsController = new Versions(controllerComponents, restorerConfig, snapshotApi, wsClient, panDomainSettings)
+  val restoreController = new Restore(controllerComponents, snapshotApi, flexibleApi, permissionsClient, restorerConfig, wsClient, panDomainSettings)
 
   def router: Router = new Routes(
     httpErrorHandler,

--- a/app/config/RestorerConfig.scala
+++ b/app/config/RestorerConfig.scala
@@ -58,7 +58,7 @@ class RestorerConfig(config: Configuration) extends AwsInstanceTags {
   private val profile: String = config.getOptional[String]("profile").getOrElse("composer")
   val creds = new AWSCredentialsProviderChain(
     new ProfileCredentialsProvider(profile),
-    new InstanceProfileCredentialsProvider
+    InstanceProfileCredentialsProvider.getInstance()
   )
 
   // Logging

--- a/app/config/aws/AWS.scala
+++ b/app/config/aws/AWS.scala
@@ -1,20 +1,19 @@
 package aws
 
-import com.amazonaws.regions.{Region, Regions}
-import com.amazonaws.services.cloudwatch.AmazonCloudWatchAsyncClient
-import com.amazonaws.services.ec2.AmazonEC2Client
-import com.amazonaws.services.ec2.model.DescribeTagsRequest
-import com.amazonaws.services.ec2.model.Filter
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.cloudwatch.{AmazonCloudWatchAsync, AmazonCloudWatchAsyncClientBuilder}
+import com.amazonaws.services.ec2.model.{DescribeTagsRequest, Filter}
+import com.amazonaws.services.ec2.{AmazonEC2, AmazonEC2ClientBuilder}
 import com.amazonaws.util.EC2MetadataUtils
-import scala.collection.JavaConverters._
 
+import scala.collection.JavaConverters._
 
 object AWS {
 
-  lazy val region = Region getRegion Regions.EU_WEST_1
+  lazy val region: Regions = Regions.EU_WEST_1
 
-  lazy val EC2Client = region.createClient(classOf[AmazonEC2Client], null, null)
-  lazy val CloudWatch = region.createClient(classOf[AmazonCloudWatchAsyncClient], null, null)
+  lazy val EC2Client: AmazonEC2 = AmazonEC2ClientBuilder.standard().withRegion(region).build()
+  lazy val CloudWatch: AmazonCloudWatchAsync = AmazonCloudWatchAsyncClientBuilder.standard().withRegion(region).build()
 
 }
 

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import helpers.Loggable
 import play.api.data.Forms._
 import play.api.data._
@@ -9,7 +10,6 @@ import play.api.mvc._
 import scala.concurrent.ExecutionContext
 
 // Pan domain
-import com.amazonaws.auth.AWSCredentialsProvider
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
 import config.RestorerConfig
@@ -24,15 +24,12 @@ trait PanDomainAuthActions extends AuthActions {
     Results.Redirect(controllers.routes.Login.authError(message))
   }
 
-  override lazy val system: String = "restorer"
   override def authCallbackUrl: String = config.hostName + "/oauthCallback"
-  override lazy val domain: String = config.domain
 
-  override def awsCredentialsProvider: AWSCredentialsProvider = config.creds
 }
 
 
-class Application(val controllerComponents: ControllerComponents, val config:RestorerConfig, override val wsClient: WSClient) extends BaseController with PanDomainAuthActions with Loggable {
+class Application(val controllerComponents: ControllerComponents, val config:RestorerConfig, override val wsClient: WSClient, val panDomainSettings: PanDomainAuthSettingsRefresher) extends BaseController with PanDomainAuthActions with Loggable {
 
   val urlForm = Form(
     "url" -> nonEmptyText
@@ -58,4 +55,5 @@ class Application(val controllerComponents: ControllerComponents, val config:Res
 
   protected val parser: BodyParser[AnyContent] = controllerComponents.parsers.default
   protected val executionContext: ExecutionContext = controllerComponents.executionContext
+
 }

--- a/app/controllers/Login.scala
+++ b/app/controllers/Login.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import config.RestorerConfig
 import helpers.Loggable
 import permissions.Permissions
@@ -10,7 +11,7 @@ import play.api.mvc._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{ExecutionContext, Future}
 
-class Login(val controllerComponents: ControllerComponents, permissionsClient: Permissions, val config: RestorerConfig, override val wsClient: WSClient)
+class Login(val controllerComponents: ControllerComponents, permissionsClient: Permissions, val config: RestorerConfig, override val wsClient: WSClient, val panDomainSettings: PanDomainAuthSettingsRefresher)
   extends BaseController with PanDomainAuthActions with Loggable {
 
   def oauthCallback = Action.async { implicit request =>

--- a/app/controllers/Management.scala
+++ b/app/controllers/Management.scala
@@ -1,12 +1,13 @@
 package controllers
 
+import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import config.RestorerConfig
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 
 import scala.concurrent.ExecutionContext
 
-class Management(val controllerComponents: ControllerComponents, val config:RestorerConfig, override val wsClient: WSClient) extends BaseController with PanDomainAuthActions {
+class Management(val controllerComponents: ControllerComponents, val config:RestorerConfig, override val wsClient: WSClient, val panDomainSettings: PanDomainAuthSettingsRefresher) extends BaseController with PanDomainAuthActions {
 
   def healthCheck = Action {
     Ok("Ok")

--- a/app/controllers/Restore.scala
+++ b/app/controllers/Restore.scala
@@ -2,6 +2,7 @@ package controllers
 
 import java.util.concurrent.TimeoutException
 
+import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import com.gu.pandomainauth.model.{User => PandaUser}
 import config.RestorerConfig
 import helpers.Loggable
@@ -19,7 +20,7 @@ import scala.language.postfixOps
 import scala.util.control.NonFatal
 
 class Restore(val controllerComponents: ControllerComponents, snapshotApi: SnapshotApi, flexibleApi: FlexibleApi, permissions: Permissions, val config: RestorerConfig,
-  val wsClient: WSClient) extends BaseController with PanDomainAuthActions with Loggable {
+  val wsClient: WSClient, val panDomainSettings: PanDomainAuthSettingsRefresher) extends BaseController with PanDomainAuthActions with Loggable {
 
   def userFromPandaUser(user: PandaUser) = User(user.firstName, user.lastName, user.email)
 

--- a/app/controllers/Versions.scala
+++ b/app/controllers/Versions.scala
@@ -1,5 +1,6 @@
 package controllers
 
+import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import config.RestorerConfig
 import helpers.Loggable
 import logic.SnapshotApi
@@ -11,7 +12,7 @@ import play.api.mvc._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class Versions(val controllerComponents: ControllerComponents, val config: RestorerConfig, snapshotApi: SnapshotApi, override val wsClient: WSClient)
+class Versions(val controllerComponents: ControllerComponents, val config: RestorerConfig, snapshotApi: SnapshotApi, override val wsClient: WSClient, val panDomainSettings: PanDomainAuthSettingsRefresher)
   extends BaseController with PanDomainAuthActions with Loggable {
   // Show a specific version
   def show(systemId: String, contentId: String, timestamp: String) = AuthAction.async {

--- a/app/helpers/LogStash.scala
+++ b/app/helpers/LogStash.scala
@@ -1,22 +1,23 @@
 package helpers
 
-import aws.{AwsInstanceTags, AWS}
+import aws.{AWS, AwsInstanceTags}
 import ch.qos.logback.classic.spi.ILoggingEvent
 import ch.qos.logback.classic.{Logger, LoggerContext}
 import ch.qos.logback.core.joran.spi.JoranException
 import ch.qos.logback.core.util.StatusPrinter
 import com.amazonaws.auth.AWSCredentialsProvider
-import com.amazonaws.regions.Region
+import com.amazonaws.regions.Regions
 import com.gu.logback.appender.kinesis.KinesisAppender
 import net.logstash.logback.layout.LogstashLayout
-import org.slf4j.{Logger => SLFLogger, LoggerFactory}
+import org.slf4j.{LoggerFactory, Logger => SLFLogger}
+
 import scala.language.postfixOps
 import scala.util.control.NonFatal
 
 case class KinesisAppenderConfig(
   stream: String,
   credentialsProvider: AWSCredentialsProvider,
-  region: Region = AWS.region,
+  region: Regions = AWS.region,
   bufferSize: Int = 1000
 )
 
@@ -34,10 +35,10 @@ object LogStash extends AwsInstanceTags with Loggable {
       Map.empty
   }
   // assume SLF4J is bound to logback in the current environment
-  lazy val context = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
+  lazy val context: LoggerContext = LoggerFactory.getILoggerFactory.asInstanceOf[LoggerContext]
 
   def makeCustomFields(customFields: Map[String,String]): String = {
-    "{" + (for((k, v) <- customFields) yield(s""""${k}":"${v}"""")).mkString(",") + "}"
+    "{" + (for((k, v) <- customFields) yield s""""$k":"$v"""").mkString(",") + "}"
   }
 
   def makeLayout(customFields: String) = {

--- a/app/logic/SnapshotApi.scala
+++ b/app/logic/SnapshotApi.scala
@@ -1,6 +1,6 @@
 package logic
 
-import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model._
 import helpers.Loggable
 import models.{Attempt, AttemptError, Snapshot, SnapshotId}
@@ -11,7 +11,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.io.Source
 import scala.util.control.NonFatal
 
-class SnapshotApi(s3Client: AmazonS3Client) extends Loggable {
+class SnapshotApi(s3Client: AmazonS3) extends Loggable {
   def listForId(bucket: String, id: String): List[SnapshotId] = listSnapshots(bucket, id)
 
   def getRawSnapshot(bucket: String, snapshotId: SnapshotId) = getObjectContentRaw(snapshotId.key, bucket)

--- a/build.sbt
+++ b/build.sbt
@@ -2,24 +2,24 @@ name := "restorer2"
 
 version := "1.0.0"
 
-scalaVersion in ThisBuild := "2.11.11"
+scalaVersion in ThisBuild := "2.12.3"
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-unused-import")
 
-val awsSdkVersion = "1.11.5"
+val awsSdkVersion = "1.11.86"
 
 libraryDependencies ++= Seq(
     ws,
-    "com.gu" %% "pan-domain-auth-play_2-6" % "0.5.1",
+    "com.gu" %% "pan-domain-auth-play_2-6" % "0.7.0",
+    "com.gu" % "kinesis-logback-appender" % "1.4.2",
+    "com.gu" %% "editorial-permissions-client" % "0.8",
     "com.typesafe.play" %% "play-json-joda" % "2.6.7",
     "net.logstash.logback" % "logstash-logback-encoder" % "4.11",
-    "com.gu" % "kinesis-logback-appender" % "1.4.2",
-    "com.gu" %% "editorial-permissions-client" % "0.3",
     "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-kinesis" % awsSdkVersion,
-    "org.scalatest" %% "scalatest" % "2.2.6" % Test
+    "org.scalatest" %% "scalatest" % "3.0.5" % Test
 )
 
 lazy val mainProject = project.in(file("."))

--- a/test/scala/models/SnapshotIdSpec.scala
+++ b/test/scala/models/SnapshotIdSpec.scala
@@ -1,9 +1,10 @@
 package scala.models
 
 import models.SnapshotId
-import org.scalatest.{FlatSpec, ShouldMatchers}
+import org.scalatest.{FlatSpec, Matchers}
+import Matchers._
 
-class SnapshotIdSpec extends FlatSpec with ShouldMatchers {
+class SnapshotIdSpec extends FlatSpec {
   "fromKey" should "extract the ID and timestamp from a key" in {
     val key = "575ee43ee4b0625eba5110f6/2016-06-13T16:57:50.306Z.json"
     SnapshotId.fromKey(key) should be(Some(SnapshotId("575ee43ee4b0625eba5110f6", "2016-06-13T16:57:50.306Z")))


### PR DESCRIPTION
Upgrades:
- `scala` 2.11.11 -> 2.12.3
- `editorial-permissions-client` 0.3 -> 0.8
- `pan-domain-auth-play_2-6` 0.5.1 -> 0.7.0
- `scalatest` 2.2.6 -> 3.0.5
- `aws` 1.11.5 -> 1.11.86

Tested on CODE