### PR TITLE
Copy JSON button

### DIFF
--- a/public/javascripts/app/controllers/SnapshotContentCtrl.js
+++ b/public/javascripts/app/controllers/SnapshotContentCtrl.js
@@ -16,6 +16,7 @@ SnapshotContentCtrlMod.controller('SnapshotContentCtrl', [
 
     $scope.isShowingJSON = false;
     $scope.displayButtonLabel = "JSON";
+    $scope.copyButtonLabel = "Copy JSON";
     $scope.canRestore =  false;
 
     UserService.get().then((user) => {
@@ -68,6 +69,8 @@ SnapshotContentCtrlMod.controller('SnapshotContentCtrl', [
       $scope.headline = model.getHeadline();
       $scope.standfirst = model.getStandfirst();
       $scope.trailText = model.getTrailText();
+
+      $scope.copyButtonLabel = "Copy JSON";
       $timeout(() => $scope.isSettingContent = false, 200);
     }
 
@@ -97,6 +100,19 @@ SnapshotContentCtrlMod.controller('SnapshotContentCtrl', [
       mediator.publish('snapshot-list:display-modal');
     }
 
+    this.copyJSON = function() {
+      const sillyHacks = document.createElement("textarea");
+      sillyHacks.value = $scope.jsonContent;
+
+      document.body.appendChild(sillyHacks);
+      sillyHacks.focus();
+      sillyHacks.select();
+
+      document.execCommand("copy");
+
+      document.body.removeChild(sillyHacks);
+      $scope.copyButtonLabel = "Copied!";
+    }
   }
 
 ]);

--- a/public/javascripts/app/templates/restore-list.html
+++ b/public/javascripts/app/templates/restore-list.html
@@ -139,6 +139,9 @@
                 </gu-btn>
                 <gu-btn class="snapshot-content__actions--button"
                 ng-click="ctrl.toggleJSON()">{{displayButtonLabel}}</gu-btn>
+                <gu-btn class="snapshot-content__actions--button" ng-click="ctrl.copyJSON()">
+                    {{copyButtonLabel}}
+                </gu-btn>
             </gu-row>
 
             <div class="snapshot-content__furniture">

--- a/public/sass/components/snapshot-content.scss
+++ b/public/sass/components/snapshot-content.scss
@@ -9,10 +9,8 @@
 
 .snapshot-content__viewport {
   width: 100%;
-  overflow: hidden;
   display: flex;
   flex-flow: column;
-  max-height: calc(100vh - 46px);
 }
 
 .snapshot-content__container {


### PR DESCRIPTION
Adding a couple of tweaks that I regularly have to do manually:

- A button that copies the JSON
- The content or JSON is rendered in full rather than being hidden (see below, sorry for tiny screenshot!)

![7b69d4253d75b94d25d2ff6324bdca48](https://user-images.githubusercontent.com/395805/42337950-2869af88-8080-11e8-9191-c09c901180cd.png)
