### PR TITLE
Export as git repo

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -40,6 +40,7 @@ class AppComponents(context: Context, config: Config) extends BuiltInComponentsF
   val managementController = new Management(controllerComponents, restorerConfig, wsClient, panDomainSettings)
   val versionsController = new Versions(controllerComponents, restorerConfig, snapshotApi, wsClient, panDomainSettings)
   val restoreController = new Restore(controllerComponents, snapshotApi, flexibleApi, permissionsClient, restorerConfig, wsClient, panDomainSettings)
+  val exportController = new Export(controllerComponents, snapshotApi, restorerConfig, wsClient, panDomainSettings)
 
   def router: Router = new Routes(
     httpErrorHandler,
@@ -48,6 +49,7 @@ class AppComponents(context: Context, config: Config) extends BuiltInComponentsF
     assets,
     managementController,
     versionsController,
-    restoreController
+    restoreController,
+    exportController
   )
 }

--- a/app/controllers/Export.scala
+++ b/app/controllers/Export.scala
@@ -24,6 +24,7 @@ class Export(override val controllerComponents: ControllerComponents, snapshotAp
   extends BaseController with PanDomainAuthActions with Loggable {
 
   private val timeout = 30.seconds
+  private implicit val executionContext = controllerComponents.executionContext
 
   def exportAsGitRepo(contentId: String) = AuthAction {
     val snapshotIds = config.sourceStacks.flatMap { stack =>
@@ -48,8 +49,7 @@ class Export(override val controllerComponents: ControllerComponents, snapshotAp
       }
 
       val zip = zipFolder(contentId, dir)
-
-      Ok(zip.toString)
+      Ok.sendFile(zip.toFile)
     }
   }
 

--- a/app/controllers/Export.scala
+++ b/app/controllers/Export.scala
@@ -14,7 +14,7 @@ import play.api.mvc.{BaseController, ControllerComponents}
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class Export(snapshotApi: SnapshotApi, override val controllerComponents: ControllerComponents, override val config: RestorerConfig,
+class Export(override val controllerComponents: ControllerComponents, snapshotApi: SnapshotApi, override val config: RestorerConfig,
              override val wsClient: WSClient, val panDomainSettings: PanDomainAuthSettingsRefresher)
 
   extends BaseController with PanDomainAuthActions with Loggable {
@@ -33,7 +33,7 @@ class Export(snapshotApi: SnapshotApi, override val controllerComponents: Contro
       val dir = Files.createTempDirectory(s"export-$contentId")
 
       snapshotIds.foreach { case(stack, id @ SnapshotId(_, timestamp)) =>
-        val filename = s"$stack-$timestamp"
+        val filename = s"${stack.stage}:${stack.stack}-$timestamp.yaml"
         val snapshot = getSnapshot(stack, id)
         Files.write(dir.resolve(filename), snapshot.getBytes(StandardCharsets.UTF_8))
       }

--- a/app/controllers/Export.scala
+++ b/app/controllers/Export.scala
@@ -1,0 +1,57 @@
+package controllers
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+
+import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import config.RestorerConfig
+import helpers.Loggable
+import logic.SnapshotApi
+import models.{FlexibleStack, SnapshotId}
+import play.api.libs.ws.WSClient
+import play.api.mvc.{BaseController, ControllerComponents}
+
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+class Export(snapshotApi: SnapshotApi, override val controllerComponents: ControllerComponents, override val config: RestorerConfig,
+             override val wsClient: WSClient, val panDomainSettings: PanDomainAuthSettingsRefresher)
+
+  extends BaseController with PanDomainAuthActions with Loggable {
+
+  private val timeout = 30.seconds
+
+  def exportAsGitRepo(contentId: String) = AuthAction {
+    val snapshotIds = config.sourceStacks.flatMap { stack =>
+      snapshotApi.listForId(stack.snapshotBucket, contentId).map(stack -> _)
+    }
+
+    if(snapshotIds.isEmpty) {
+      NotFound(s"$contentId does not have any snapshots")
+    } else {
+      // TODO MRB: delete directory once download complete
+      val dir = Files.createTempDirectory(s"export-$contentId")
+
+      snapshotIds.foreach { case(stack, id @ SnapshotId(_, timestamp)) =>
+        val filename = s"$stack-$timestamp"
+        val snapshot = getSnapshot(stack, id)
+        Files.write(dir.resolve(filename), snapshot.getBytes(StandardCharsets.UTF_8))
+      }
+
+      Ok(dir.toString)
+    }
+  }
+
+  private def getSnapshot(stack: FlexibleStack, id: SnapshotId): String = {
+    Await.result(snapshotApi.getRawSnapshot(stack.snapshotBucket, id).asFuture(controllerComponents.executionContext), timeout) match {
+      case Left(err) =>
+        throw new IllegalStateException(err.toString)
+
+      case Right(None) =>
+        throw new IllegalStateException(s"Missing snapshot for $stack $id")
+
+      case Right(Some(snapshot)) =>
+        snapshot
+    }
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ libraryDependencies ++= Seq(
     "com.gu" %% "configraun" % "0.3",
     "com.typesafe.play" %% "play-json-joda" % "2.6.7",
     "net.logstash.logback" % "logstash-logback-encoder" % "4.11",
+    "org.eclipse.jgit" % "org.eclipse.jgit" % "5.1.1.201809181055-r",
     "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,8 @@ libraryDependencies ++= Seq(
     "org.eclipse.jgit" % "org.eclipse.jgit" % "5.1.1.201809181055-r",
     "commons-io" % "commons-io" % "2.6",
     "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % "2.9.2",
+    "org.jsoup" % "jsoup" % "1.11.3",
+    "com.lihaoyi" %% "ujson" % "0.6.6",
     "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,8 @@ libraryDependencies ++= Seq(
     "com.typesafe.play" %% "play-json-joda" % "2.6.7",
     "net.logstash.logback" % "logstash-logback-encoder" % "4.11",
     "org.eclipse.jgit" % "org.eclipse.jgit" % "5.1.1.201809181055-r",
+    "commons-io" % "commons-io" % "2.6",
+    "com.fasterxml.jackson.dataformat" % "jackson-dataformat-yaml" % "2.9.2",
     "com.amazonaws" % "aws-java-sdk-s3" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-ec2" % awsSdkVersion,
     "com.amazonaws" % "aws-java-sdk-cloudwatch" % awsSdkVersion,

--- a/conf/routes
+++ b/conf/routes
@@ -25,3 +25,5 @@ GET           /api/1/user/permissions                                           
 GET           /api/1/version-count/:contentId                                         controllers.Versions.availableVersionsCount(contentId: String)
 POST          /api/1/restore/:sourceId/:contentId/:timestamp/to/:destinationId        controllers.Restore.restore(sourceId: String, contentId: String, timestamp: String, destinationId: String)
 GET           /api/1/restore/destinations/:contentId                                  controllers.Restore.restoreDestinations(contentId: String)
+
+GET           /export/:contentId/git  controllers.Export.exportAsGitRepo(contentId: String)

--- a/public/javascripts/app/controllers/SnapshotContentCtrl.js
+++ b/public/javascripts/app/controllers/SnapshotContentCtrl.js
@@ -12,7 +12,8 @@ SnapshotContentCtrlMod.controller('SnapshotContentCtrl', [
   'SnapshotIdModels',
     'SnapshotModels',
     'UserService',
-  function($scope, $routeParams, $timeout, $sce, SnapshotIdModels, SnapshotModels, UserService){
+    'SnapshotService',
+  function($scope, $routeParams, $timeout, $sce, SnapshotIdModels, SnapshotModels, UserService, SnapshotService){
 
     $scope.isShowingJSON = false;
     $scope.displayButtonLabel = "JSON";
@@ -112,6 +113,12 @@ SnapshotContentCtrlMod.controller('SnapshotContentCtrl', [
 
       document.body.removeChild(sillyHacks);
       $scope.copyButtonLabel = "Copied!";
+    }
+
+    this.exportAsGit = function() {
+      SnapshotService.exportAsGit($routeParams.contentId)
+        .then(r => console.log(r))
+        .catch((err) => mediator.publish('error', err));
     }
   }
 

--- a/public/javascripts/app/controllers/SnapshotContentCtrl.js
+++ b/public/javascripts/app/controllers/SnapshotContentCtrl.js
@@ -12,11 +12,11 @@ SnapshotContentCtrlMod.controller('SnapshotContentCtrl', [
   'SnapshotIdModels',
     'SnapshotModels',
     'UserService',
-    'SnapshotService',
-  function($scope, $routeParams, $timeout, $sce, SnapshotIdModels, SnapshotModels, UserService, SnapshotService){
+  function($scope, $routeParams, $timeout, $sce, SnapshotIdModels, SnapshotModels, UserService){
 
+    $scope.contentId = $routeParams.contentId;
     $scope.isShowingJSON = false;
-    $scope.displayButtonLabel = "JSON";
+    $scope.displayButtonLabel = "Show JSON";
     $scope.copyButtonLabel = "Copy JSON";
     $scope.canRestore =  false;
 
@@ -78,14 +78,14 @@ SnapshotContentCtrlMod.controller('SnapshotContentCtrl', [
     function displayJSON() {
       safeApply($scope, () => {
           $scope.isShowingJSON = true;
-          $scope.displayButtonLabel = "TEXT";
+          $scope.displayButtonLabel = "Show TEXT";
       });
     }
 
     function displayHTML() {
       safeApply($scope, () => {
           $scope.isShowingJSON = false;
-          $scope.displayButtonLabel = "JSON";
+          $scope.displayButtonLabel = "Show JSON";
       });
     }
 
@@ -113,12 +113,6 @@ SnapshotContentCtrlMod.controller('SnapshotContentCtrl', [
 
       document.body.removeChild(sillyHacks);
       $scope.copyButtonLabel = "Copied!";
-    }
-
-    this.exportAsGit = function() {
-      SnapshotService.exportAsGit($routeParams.contentId)
-        .then(r => console.log(r))
-        .catch((err) => mediator.publish('error', err));
     }
   }
 

--- a/public/javascripts/app/services/SnapshotCollectionService.js
+++ b/public/javascripts/app/services/SnapshotCollectionService.js
@@ -8,7 +8,8 @@ SnapshotServiceMod.service('SnapshotService', [
     return {
       get: (id) => $http.get(`/api/1/versions/${id}`),
       getList: (id) => $http.get(`/api/1/versionList/${id}`),
-      getSnapshot: (systemId, contentId, timestamp) => $http.get(`/api/1/version/${systemId}/${contentId}/${timestamp}`)
+      getSnapshot: (systemId, contentId, timestamp) => $http.get(`/api/1/version/${systemId}/${contentId}/${timestamp}`),
+      exportAsGit: (id) => $http.get(`/export/${id}/git`)
     }
   }
 ]);

--- a/public/javascripts/app/services/SnapshotCollectionService.js
+++ b/public/javascripts/app/services/SnapshotCollectionService.js
@@ -8,8 +8,7 @@ SnapshotServiceMod.service('SnapshotService', [
     return {
       get: (id) => $http.get(`/api/1/versions/${id}`),
       getList: (id) => $http.get(`/api/1/versionList/${id}`),
-      getSnapshot: (systemId, contentId, timestamp) => $http.get(`/api/1/version/${systemId}/${contentId}/${timestamp}`),
-      exportAsGit: (id) => $http.get(`/export/${id}/git`)
+      getSnapshot: (systemId, contentId, timestamp) => $http.get(`/api/1/version/${systemId}/${contentId}/${timestamp}`)
     }
   }
 ]);

--- a/public/javascripts/app/templates/restore-list.html
+++ b/public/javascripts/app/templates/restore-list.html
@@ -142,6 +142,9 @@
                 <gu-btn class="snapshot-content__actions--button" ng-click="ctrl.copyJSON()">
                     {{copyButtonLabel}}
                 </gu-btn>
+                <gu-btn class="snapshot-content__actions--button" ng-click="ctrl.exportAsGit()">
+                    Export all as Git Repo
+                </gu-btn>
             </gu-row>
 
             <div class="snapshot-content__furniture">

--- a/public/javascripts/app/templates/restore-list.html
+++ b/public/javascripts/app/templates/restore-list.html
@@ -137,13 +137,14 @@
                     <gu-icon class="snapshot-content__actions__restore__icon" variant="wrench-disabled"></gu-icon>
                     Restore
                 </gu-btn>
-                <gu-btn class="snapshot-content__actions--button"
-                ng-click="ctrl.toggleJSON()">{{displayButtonLabel}}</gu-btn>
                 <gu-btn class="snapshot-content__actions--button" ng-click="ctrl.copyJSON()">
                     {{copyButtonLabel}}
                 </gu-btn>
-                <gu-btn class="snapshot-content__actions--button" ng-click="ctrl.exportAsGit()">
+                <a class="snapshot-content__actions--button btn btn" target="_blank" ng-href="/export/{{contentId}}/git">
                     Export all as Git Repo
+                </a>
+                <gu-btn class="snapshot-content__actions--button" ng-click="ctrl.toggleJSON()">
+                    {{displayButtonLabel}}
                 </gu-btn>
             </gu-row>
 

--- a/public/sass/components/snapshot-content.scss
+++ b/public/sass/components/snapshot-content.scss
@@ -77,6 +77,8 @@
     align-items: center;
     justify-content: center;
     background: $box-tertiary-bg;
+    font-family: "Guardian Agate Sans";
+    font-size: 11px;
     & :last-child {
         margin-right: 0;
     }


### PR DESCRIPTION
As a developer, I often want to inspect the various snapshots from restorer to try and work out what steps happened in the lead up to a problem. The current UI makes that difficult as you have to click on each snapshot, export as JSON, prettify it and then diff.

To make this process easier I have added a new option to export all the snapshots as a git repo. You can then load them up into your git tooling of choice to easily look at the diffs. Each commit is created with the correct user (based on `lastModified`).

Three files are created in the repo: `preview`, `live` and `metadata`. The files are YAML and the HTML has been prettified as much as possible. The results are dangerously close to readable:

<img width="1280" alt="84fc3774529c8493523199594e77b3de" src="https://user-images.githubusercontent.com/395805/46944518-27582900-d06a-11e8-8265-468fc4eb1ca2.png">
