### PR TITLE
add overflow to content to see all of it

### DIFF
--- a/public/sass/components/snapshot-content.scss
+++ b/public/sass/components/snapshot-content.scss
@@ -12,6 +12,7 @@
   display: flex;
   flex-flow: column;
   max-height: calc(100vh - 46px);
+  overflow: scroll;
 }
 
 .snapshot-content__container {


### PR DESCRIPTION
I'm unable to record a GIF of this 😢 

# Before (cannot scroll RHS)
![image](https://user-images.githubusercontent.com/836140/72524092-1132ad00-3859-11ea-88d6-545e2eacaef7.png)

# After (can scroll RHS)
![image](https://user-images.githubusercontent.com/836140/72524145-30c9d580-3859-11ea-80eb-72770ea29277.png)
