### PR TITLE
highlight launch events (e.g. Published, On 'Save and Launch' etc.)

### DIFF
--- a/public/javascripts/app/models/SnapshotIdModel.js
+++ b/public/javascripts/app/models/SnapshotIdModel.js
@@ -73,6 +73,11 @@ SnapshotIdModelMod.factory('SnapshotIdModel', [
                 return this.get('metadata.reason')
             }
 
+            isBecauseOfLaunch() {
+                const reason = this.getSnapshotReason() || '';
+                return reason === 'Published' || reason.toLowerCase().includes('launch')
+            }
+
             isLegallySensitive() {
                 const legallySensitive = this.get('summary.preview.settings.legallySensitive');
                 return legallySensitive === "true";

--- a/public/javascripts/app/templates/restore-list.html
+++ b/public/javascripts/app/templates/restore-list.html
@@ -57,17 +57,20 @@
                 variant="{{ model.get('activeState') ? 'tertiary' : 'primary' }}"
                 ng-mouseenter="hovered=true"
                 ng-mouseleave="hovered=false"
-                ng-class="{ 'item-active': model.get('activeState') }">
+                ng-class="{ 'item-active': model.get('activeState'), 'highlight-row-for-launches': model.isBecauseOfLaunch()  }">
 
                 <div class="index-list__item__index">{{model.getRevisionId() || (models.length - $index)}}</div>
 
                 <div class="snapshot-list__item__content"
-                     ng-class="{ 'active': model.get('activeState') && isDisplayingHTML }"
+                     ng-class="{ 'active': model.get('activeState') && isDisplayingHTML}"
                      ng-click="ctrl.onItemClicked($index)">
                     <h6 class="snapshot-list__item__content__actual-date" ng-bind-html="model.getCreatedDateHtml()"></h6>
                     <h6 class="snapshot-list__item__content__relative-date">{{ model.getRelativeDate() }} ago</h6>
                     <h6 class="snapshot-list__item__content__reason">Last modified by: {{ model.getUserEmail() }}</h6>
-                    <h6 class="snapshot-list__item__content__reason">{{ model.getSnapshotReason() }}</h6>
+                    <h6 class="snapshot-list__item__content__reason"
+                        ng-class="{ 'highlight-reason-for-launches': model.isBecauseOfLaunch() }">
+                        {{ model.getSnapshotReason() }}
+                    </h6>
                 </div>
 
                 <div class="snapshot-list__item__information">

--- a/public/sass/components/text.scss
+++ b/public/sass/components/text.scss
@@ -55,6 +55,25 @@
   font-size: 13px;
 }
 
+.highlight-row-for-launches {
+    border: 2px solid $color-500-grey;
+    .snapshot-list__item__status--right::after {
+        border: none;
+        display: block;
+        position: absolute;
+        top: 5px;
+        right: 5px;
+        content: '🚀';
+        font-size: 150%;
+        opacity: 0.6;
+        filter: grayscale(100%);
+    }
+}
+.highlight-reason-for-launches {
+    font-weight: bold;
+    font-size: 15px;
+}
+
 .snapshot-list__item__content__actual-date {
   font-family: "Guardian Agate Sans";
   font-weight: bold;


### PR DESCRIPTION
https://trello.com/c/ofRJAdOq/2066-make-save-and-launch-snapshots-more-prominent-in-restorer

## What does this change?
On busy pieces it can be difficult to see the key launch events (e.g. `Published`, `On 'Save and Launch'` etc.) so this highlights them with...

- Bolded & enlarged reason text
- border round the card
- greyscale 🚀 emoji (because why not - can remove though)

## How to test
Deploy to `CODE` create an article, do some 'Save and Close', then publish it, some more 'Save and close', then some 'Save and launch' then view it all in restorer (use Teleporter to hop over or hit https://restorer.code.dev-gutools.co.uk/ to go there manually)

## How can we measure success?
Easier for subs to diff different versions that we actually published.

## Have we considered potential risks?
Minimal risk of this styling only change (of a lesser used tool).

## Images
![image](https://user-images.githubusercontent.com/19289579/95565498-359e6d00-0a18-11eb-8f80-a041b021d27d.png)
