### PR TITLE
Move restorer to Graviton

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -13,7 +13,7 @@ deployments:
     app: restorer2
     parameters:
       amiTags:
-        Recipe: editorial-tools-xenial-java8
+        Recipe: editorial-tools-bionic-java8-ARM
         AmigoStage: PROD
         BuiltBy: amigo
       amiEncrypted: true


### PR DESCRIPTION
## What does this change?
Moves restorer to an ARM-based AMI to run on the new Graviton instances.

##  How to test
The app should work as before! Tested in CODE. We'll need to move to the new instance type, and then deploy this PR to use the new AMI.

## How can we measure success?
Restorer runs on Graviton.

Have we considered potential risks?
Tested in CODE. We'll need to manually update the cloudformation to the previous version and then redeploy the tool with the non-Graviton image should we wish to roll back.
