### PR TITLE
upgrade AWS SDK to min. version required for IMDSv2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ scalaVersion in ThisBuild := "2.12.3"
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-feature", "-Ywarn-unused-import")
 
-val awsSdkVersion = "1.11.86"
+val awsSdkVersion = "1.11.678"
 
 libraryDependencies ++= Seq(
     ws,


### PR DESCRIPTION
_This is a pre-requisite for https://github.com/guardian/editorial-tools-platform/pull/528_

Upgrade AWS SDK to min. version required for IMDSv2 to address https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#ec2-8-remediation as per https://github.com/guardian/security-hq/blob/main/hq/markdown/guardduty-sechub-common-problems.md#ec2-instances-should-use-imdsv2

**✅  Tested in `CODE`**, the below graph shows drop-off in usage of IMDSv1 for the relevant ASG...
![image](https://user-images.githubusercontent.com/19289579/115229689-40466700-a10b-11eb-9524-7fdb06880301.png)
