### PR TITLE
Fix name of deb file to match AWS launch configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,10 @@ jobs:
               run: |
                   sbt clean compile test Debian/packageBin
 
+            - name: Rename file to match Launch Configuration in AWS
+              run: |
+                  - mv target/restorer2_1.0.0_all.deb restorer2.deb
+
             # Fetch AWS credentials, allowing us to upload to Riff-Raff (well, S3)
             - uses: aws-actions/configure-aws-credentials@v2
               with:
@@ -64,4 +68,4 @@ jobs:
                   configPath: riff-raff.yaml
                   contentDirectories: |
                       restorer2:
-                        - target/restorer2_1.0.0_all.deb
+                        - restorer2.deb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
             - name: Rename file to match Launch Configuration in AWS
               run: |
-                  - mv target/restorer2_1.0.0_all.deb restorer2.deb
+                  mv target/restorer2_1.0.0_all.deb restorer2.deb
 
             # Fetch AWS credentials, allowing us to upload to Riff-Raff (well, S3)
             - uses: aws-actions/configure-aws-credentials@v2


### PR DESCRIPTION
## What does this change?
This fixes our CI pipeline by renaming the `.deb` file to be the same as what is expected by the launch configuration in AWS - https://github.com/guardian/editorial-tools-platform/blob/main/cloudformation/composer-account/flexible-content/restorer.yaml#L380.

## How to test
This has been deployed to CODE and I can see the new `restorer2.deb`  file appear with a timestamp that matches the deploy time in the `composer-dist` bucket.