### PR TITLE
Ensure 🚀 shows for channel launch events before piece is actually 'fully' published

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
                   mv target/restorer2_1.0.0_all.deb restorer2.deb
 
             # Fetch AWS credentials, allowing us to upload to Riff-Raff (well, S3)
-            - uses: aws-actions/configure-aws-credentials@v2
+            - uses: aws-actions/configure-aws-credentials@v4
               with:
                   role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
                   aws-region: eu-west-1

--- a/public/sass/components/text.scss
+++ b/public/sass/components/text.scss
@@ -57,7 +57,7 @@
 
 .highlight-row-for-launches {
     border: 2px solid $color-500-grey;
-    .snapshot-list__item__status--right::after {
+    .snapshot-list__item__status::after {
         border: none;
         display: block;
         position: absolute;


### PR DESCRIPTION
_PR remade/copied from https://github.com/guardian/flexible-restorer/pull/98 as I foolishly put the 🚀 emoji in the original branch name and GitHub barfed. Previous PR was tested & approved by @Fweddi_
<hr/>
Users have noticed the 🚀  emoji (added in https://github.com/guardian/flexible-restorer/pull/53) didn't display for Channel launch events unless they were after the piece is 'fully' published - this was because the `::after` element which displays the 🚀 was bound to an element which didn't display unless the piece is overall published (which isn't the case for some channel launches, obviously). This PR just corrects that CSS selector.

It's still up for debate whether restorer should show pieces launched to just some channels more explicitly in place of the 'Published' flag.