### PR TITLE
LOG interactions where users don't have `restorer_access` permission 

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -1,11 +1,11 @@
 import com.gu.AppIdentity
+import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import com.gu.permissions.{PermissionsConfig, PermissionsProvider}
 import config.AppConfig
 import config.AWS._
 import controllers._
 import helpers.{HSTSFilter, Loggable}
 import logic.{FlexibleApi, SnapshotApi}
-import permissions.Permissions
 import play.api.ApplicationLoader.Context
 import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.EssentialFilter
@@ -21,23 +21,30 @@ class AppComponents(context: Context, identity: AppIdentity) extends BuiltInComp
 
   val config = new AppConfig(configuration, identity)
 
-  val permissionsConfig = PermissionsConfig(
+  val permissions = PermissionsProvider(PermissionsConfig(
     stage = config.stage,
     region = config.region,
     awsCredentials = credentialsV1
+  ))
+
+  val panDomainSettings: PanDomainAuthSettingsRefresher = new PanDomainAuthSettingsRefresher(
+    domain = config.domain,
+    system = "restorer",
+    bucketName = "pan-domain-auth-settings",
+    settingsFileKey = s"${config.domain}.settings",
+    s3Client = S3ClientV1
   )
-  val permissionsClient = PermissionsProvider(permissionsConfig)
 
   val snapshotApi = new SnapshotApi(s3Client)
 
   val flexibleApi = new FlexibleApi(wsClient)
 
-  val applicationController = new Application(controllerComponents, config, wsClient, config.panDomainSettings)
-  val loginController = new Login(controllerComponents, permissionsClient, config, wsClient, config.panDomainSettings)
-  val managementController = new Management(controllerComponents, config, wsClient, config.panDomainSettings)
-  val versionsController = new Versions(controllerComponents, config, snapshotApi, wsClient, config.panDomainSettings)
-  val restoreController = new Restore(controllerComponents, snapshotApi, flexibleApi, permissionsClient, config, wsClient, config.panDomainSettings)
-  val exportController = new Export(controllerComponents, snapshotApi, config, wsClient, config.panDomainSettings)
+  val applicationController = new Application(controllerComponents, config, wsClient, permissions, panDomainSettings)
+  val loginController = new Login(controllerComponents, config, wsClient, permissions, panDomainSettings)
+  val managementController = new Management(controllerComponents, config, wsClient, permissions, panDomainSettings)
+  val versionsController = new Versions(controllerComponents, config, snapshotApi, wsClient, permissions, panDomainSettings)
+  val restoreController = new Restore(controllerComponents, snapshotApi, flexibleApi, config, wsClient, permissions, panDomainSettings)
+  val exportController = new Export(controllerComponents, snapshotApi, config, wsClient, permissions, panDomainSettings)
 
   def router: Router = new Routes(
     httpErrorHandler,

--- a/app/auth/PanDomainAuthActions.scala
+++ b/app/auth/PanDomainAuthActions.scala
@@ -1,0 +1,37 @@
+package auth
+
+import com.gu.pandomainauth.action.AuthActions
+import com.gu.pandomainauth.model.AuthenticatedUser
+import com.gu.permissions.{PermissionDefinition, PermissionsProvider}
+import config.AppConfig
+import helpers.Loggable
+import permissions.Permissions
+import play.api.mvc.{RequestHeader, Result, Results}
+
+trait PanDomainAuthActions extends AuthActions with Loggable {
+  def config: AppConfig
+
+  def permissions: PermissionsProvider
+
+  override def validateUser(authedUser: AuthenticatedUser): Boolean = {
+    val isValid = (authedUser.user.emailDomain == "guardian.co.uk") && authedUser.multiFactor
+
+    val hasRestorerAccess = permissions.hasPermission(Permissions.RestorerAccess, authedUser.user.email)
+
+    if (!isValid) {
+      logger.warn(s"User ${authedUser.user.email} failed validation")
+    }
+    if (!hasRestorerAccess) {
+      logger.warn(s"User ${authedUser.user.email} doesn't have 'restorer_access' permission.")
+    }
+
+    isValid // && hasRestorerAccess TODO add this back in after two weeks of logs to actually enforce
+  }
+
+  override def showUnauthedMessage(message: String)(implicit request: RequestHeader): Result = {
+    Results.Redirect(controllers.routes.Login.authError(message))
+  }
+
+  override def authCallbackUrl: String = config.hostName + "/oauthCallback"
+
+}

--- a/app/auth/PanDomainAuthActions.scala
+++ b/app/auth/PanDomainAuthActions.scala
@@ -1,5 +1,6 @@
 package auth
 
+import com.gu.pandomainauth.PanDomain
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
 import com.gu.permissions.{PermissionDefinition, PermissionsProvider}
@@ -14,7 +15,7 @@ trait PanDomainAuthActions extends AuthActions with Loggable {
   def permissions: PermissionsProvider
 
   override def validateUser(authedUser: AuthenticatedUser): Boolean = {
-    val isValid = (authedUser.user.emailDomain == "guardian.co.uk") && authedUser.multiFactor
+    val isValid = PanDomain.guardianValidation(authedUser)
 
     val hasRestorerAccess = permissions.hasPermission(Permissions.RestorerAccess, authedUser.user.email)
 

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -61,13 +61,6 @@ class AppConfig(configuration: Configuration, identity: AppIdentity) {
   // GA
   lazy val googleTrackingId: String = underlyingConfig.getString("google.tracking.id")
 
-  val panDomainSettings: PanDomainAuthSettingsRefresher = new PanDomainAuthSettingsRefresher(
-    domain,
-    system = "restorer",
-    bucketName = "pan-domain-auth-settings",
-    settingsFileKey = s"$domain.settings",
-    s3Client = S3ClientV1
-  )
 }
 
 object AppConfig {

--- a/app/controllers/Application.scala
+++ b/app/controllers/Application.scala
@@ -1,6 +1,8 @@
 package controllers
 
+import auth.PanDomainAuthActions
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.permissions.PermissionsProvider
 import helpers.Loggable
 import play.api.data.Forms._
 import play.api.data._
@@ -16,21 +18,16 @@ import com.gu.pandomainauth.model.AuthenticatedUser
 import config.AppConfig
 import helpers.CORSable
 
-trait PanDomainAuthActions extends AuthActions {
-  def config:AppConfig
-
-  override def validateUser(authedUser: AuthenticatedUser): Boolean = authedUser.multiFactor
-
-  override def showUnauthedMessage(message: String)(implicit request: RequestHeader): Result = {
-    Results.Redirect(controllers.routes.Login.authError(message))
-  }
-
-  override def authCallbackUrl: String = config.hostName + "/oauthCallback"
-
-}
 
 
-class Application(val controllerComponents: ControllerComponents, val config:AppConfig, override val wsClient: WSClient, val panDomainSettings: PanDomainAuthSettingsRefresher) extends BaseController with PanDomainAuthActions with Loggable {
+
+class Application(
+  val controllerComponents: ControllerComponents,
+  val config:AppConfig,
+  override val wsClient: WSClient,
+  override val permissions: PermissionsProvider,
+  val panDomainSettings: PanDomainAuthSettingsRefresher
+) extends BaseController with PanDomainAuthActions with Loggable {
 
   val urlForm = Form(
     "url" -> nonEmptyText

--- a/app/controllers/Export.scala
+++ b/app/controllers/Export.scala
@@ -1,8 +1,10 @@
 package controllers
 
+import auth.PanDomainAuthActions
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.{YAMLGenerator, YAMLMapper}
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.permissions.PermissionsProvider
 import config.AppConfig
 import helpers.Loggable
 import logic.SnapshotApi
@@ -26,8 +28,14 @@ import scala.concurrent.{Await, ExecutionContext}
 import scala.concurrent.duration._
 import scala.util.Try
 
-class Export(override val controllerComponents: ControllerComponents, snapshotApi: SnapshotApi, override val config: AppConfig,
-             override val wsClient: WSClient, val panDomainSettings: PanDomainAuthSettingsRefresher)
+class Export(
+  override val controllerComponents: ControllerComponents,
+  snapshotApi: SnapshotApi,
+  override val config: AppConfig,
+  override val wsClient: WSClient,
+  override val permissions: PermissionsProvider,
+  override val panDomainSettings: PanDomainAuthSettingsRefresher
+)
 
   extends BaseController with PanDomainAuthActions with Loggable {
 

--- a/app/controllers/Management.scala
+++ b/app/controllers/Management.scala
@@ -1,13 +1,21 @@
 package controllers
 
+import auth.PanDomainAuthActions
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.permissions.PermissionsProvider
 import config.{AWS, AppConfig}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
 
 import scala.concurrent.ExecutionContext
 
-class Management(val controllerComponents: ControllerComponents, val config:AppConfig, override val wsClient: WSClient, val panDomainSettings: PanDomainAuthSettingsRefresher) extends BaseController with PanDomainAuthActions {
+class Management(
+  val controllerComponents: ControllerComponents,
+  val config:AppConfig,
+  override val wsClient: WSClient,
+  override val permissions: PermissionsProvider,
+  override val panDomainSettings: PanDomainAuthSettingsRefresher
+) extends BaseController with PanDomainAuthActions {
 
   def healthCheck = Action {
     Ok("Ok")

--- a/app/controllers/Versions.scala
+++ b/app/controllers/Versions.scala
@@ -1,6 +1,8 @@
 package controllers
 
+import auth.PanDomainAuthActions
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.permissions.PermissionsProvider
 import config.AppConfig
 import helpers.Loggable
 import logic.SnapshotApi
@@ -12,8 +14,14 @@ import play.api.mvc._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class Versions(val controllerComponents: ControllerComponents, val config: AppConfig, snapshotApi: SnapshotApi, override val wsClient: WSClient, val panDomainSettings: PanDomainAuthSettingsRefresher)
-  extends BaseController with PanDomainAuthActions with Loggable {
+class Versions(
+  val controllerComponents: ControllerComponents,
+  val config: AppConfig,
+  snapshotApi: SnapshotApi,
+  override val wsClient: WSClient,
+  override val permissions: PermissionsProvider,
+  override val panDomainSettings: PanDomainAuthSettingsRefresher
+) extends BaseController with PanDomainAuthActions with Loggable {
   // Show a specific version
   def show(systemId: String, contentId: String, timestamp: String) = AuthAction.async {
     val stack = config.stackFromId(systemId)

--- a/app/permissions/Permissions.scala
+++ b/app/permissions/Permissions.scala
@@ -5,6 +5,8 @@ import com.gu.permissions.PermissionDefinition
 object Permissions {
   val app = "composer-restorer"
 
+  val RestorerAccess: PermissionDefinition = PermissionDefinition("restorer_access", app)
+
   val RestoreContent: PermissionDefinition = PermissionDefinition("restore_content", app)
 
   val RestoreContentToAlternateStack: PermissionDefinition = PermissionDefinition("restore_content_to_any_stack", app)

--- a/conf/routes
+++ b/conf/routes
@@ -21,7 +21,7 @@ GET            /management/info                            controllers.Managemen
 GET           /api/1/versionList/:contentId                                           controllers.Versions.versionList(contentId: String)
 GET           /api/1/version/:systemId/:contentId/:timestamp                          controllers.Versions.show(systemId: String, contentId: String, timestamp: String)
 GET           /api/1/user                                                             controllers.Login.user
-GET           /api/1/user/permissions                                                 controllers.Login.permissions
+GET           /api/1/user/permissions                                                 controllers.Login.usersPermissions
 GET           /api/1/version-count/:contentId                                         controllers.Versions.availableVersionsCount(contentId: String)
 POST          /api/1/restore/:sourceId/:contentId/:timestamp/to/:destinationId        controllers.Restore.restore(sourceId: String, contentId: String, timestamp: String, destinationId: String)
 GET           /api/1/restore/destinations/:contentId                                  controllers.Restore.restoreDestinations(contentId: String)


### PR DESCRIPTION
https://github.com/guardian/permissions/pull/191 adds a new `restorer_access` permission and in this PR just logs interactions with restorer where users don't have this new `restorer_access` permission, with a placeholder for enforcing later.

Also includes some refactors to rearrange panda & permissions more neatly.