### PR TITLE
ENFORCE `restorer_access` permission

### DIFF
--- a/app/auth/PanDomainAuthActions.scala
+++ b/app/auth/PanDomainAuthActions.scala
@@ -3,7 +3,7 @@ package auth
 import com.gu.pandomainauth.PanDomain
 import com.gu.pandomainauth.action.AuthActions
 import com.gu.pandomainauth.model.AuthenticatedUser
-import com.gu.permissions.{PermissionDefinition, PermissionsProvider}
+import com.gu.permissions.PermissionsProvider
 import config.AppConfig
 import helpers.Loggable
 import permissions.Permissions
@@ -26,7 +26,7 @@ trait PanDomainAuthActions extends AuthActions with Loggable {
       logger.warn(s"User ${authedUser.user.email} doesn't have 'restorer_access' permission.")
     }
 
-    isValid // && hasRestorerAccess TODO add this back in after two weeks of logs to actually enforce
+    isValid && hasRestorerAccess
   }
 
   override def showUnauthedMessage(message: String)(implicit request: RequestHeader): Result = {

--- a/app/views/authError.scala.html
+++ b/app/views/authError.scala.html
@@ -10,7 +10,7 @@
 <div class="find-snapshots">
     <h2>Composer Restorer: Access denied</h2>
     <p>@message</p>
-    <p>If you would like to have a previous version of a piece of content restored, please contact <a href="mailto:central.production@@guardian.co.uk">Central Production</a> for assistance.</p>
+    <p>If you would like view previous versions OR to have a previous version of a piece of content restored, please contact <a href="mailto:central.production@@guardian.co.uk">Central Production</a> for assistance.</p>
 </div>
 </body>
 </html>


### PR DESCRIPTION
Following on from https://github.com/guardian/flexible-restorer/pull/103 which was LOGGING ONLY - this PR enforces the `restorer_access` permission (added in https://github.com/guardian/permissions/pull/193).