### PR TITLE
set local permissions to read from code (the "effective stage")

### DIFF
--- a/app/AppComponents.scala
+++ b/app/AppComponents.scala
@@ -22,7 +22,7 @@ class AppComponents(context: Context, identity: AppIdentity) extends BuiltInComp
   val config = new AppConfig(configuration, identity)
 
   val permissions = PermissionsProvider(PermissionsConfig(
-    stage = config.stage,
+    stage = config.effectiveStage,
     region = config.region,
     awsCredentials = credentialsV1
   ))


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Running locally currently tries to read permissions from the "DEV" area in CODE permissions - which doesn't exist. Instead read from the "effective" stage (CODE), as is common in other tools. This restores the ability to restore from CODE to LOCAL flex, by simultaneously running flex and restorer locally, and feeding it the URL of a composer page that exists in CODE.

## How to test

Run locally, as described above. Can you restore CODE to LOCAL?

## How can we measure success?

Better debugging of odd content by enabling the old restore chain of PROD -> CODE -> Local