### PR TITLE
Add support for list-y formats

### DIFF
--- a/public/javascripts/app/models/SnapshotModel.js
+++ b/public/javascripts/app/models/SnapshotModel.js
@@ -40,14 +40,22 @@ SnapshotModelMod.factory('SnapshotModel', [
       getHTMLContent(){
         var content = this.get('snapshot.preview').blocks.map((block) => block.elements);
         content = flatten(content);
-        return content.map((element) => {
-          if (element.fields.text) {
-            return element.fields.text;
-          }
-          if (element.fields.html) {
-            return element.fields.html;
-          }
-        }).join('');
+        function htmlFromElements(elements) {
+            return elements.map((element) => {
+                if (element.fields.text) {
+                    return element.fields.text;
+                }
+                if (element.fields.html) {
+                    return element.fields.html;
+                }
+                if (element.fields.items) {
+                    return element.fields.items.map((item) => {
+                        return `<h2>${item.title}</h2>` + htmlFromElements(item.content)
+                    }).join('');
+                }
+            }).join('');
+        }
+        return htmlFromElements(content);
       }
 
       get(key){


### PR DESCRIPTION
## What does this change?

Restorer does track list-y formats (like key takeaways), but does not render them correctly. This PR is an initial rendering, mainly to provide reassurance to users that their content is safe.

<img width="1458" alt="Screenshot 2024-06-25 at 11 15 48" src="https://github.com/guardian/flexible-restorer/assets/2619836/b4f40172-1694-4510-85a3-2ab47c41d9c9">
