### PR TITLE
Support Timelines, Mini-profiles and Multi-bylines in Restorer preview

### DIFF
--- a/public/javascripts/app/models/SnapshotModel.js
+++ b/public/javascripts/app/models/SnapshotModel.js
@@ -6,6 +6,21 @@ import BaseModel from './BaseModel';
 
 var SnapshotModelMod = angular.module('SnapshotModelMod', []);
 
+
+const getListItemContent = (item, htmlFromElements) => {
+    const title = item.title ? `<h2>${item.title}</h2>` : "";
+    const bio = item.bio ? `${item.bio}` : "";
+    const endNote = item.endNote ? `<p><em>${item.endNote}</em></p>` : "";
+    const byline = item.byline ? `<p>${byline}</p>` : "";
+    return `${title} ${byline} ${bio} ${htmlFromElements(item.content)} ${endNote}`
+}
+
+const getTimelineEventContent = (event, htmlFromElements) => {
+    const title = event.title ? `<h2>${event.title}</h2>` : "";
+    const date = event.date ? `<p>${event.date}</p>` : "";
+    return `${title} ${date} ${htmlFromElements(event.body)}`
+}
+
 SnapshotModelMod.factory('SnapshotModel', [
   function(){
 
@@ -37,20 +52,6 @@ SnapshotModelMod.factory('SnapshotModel', [
           return this.get("snapshot.preview.fields.trailText");
       }
 
-      getListItemContent(item, htmlFromElements) {
-          const title = item.title ? `<h2>${item.title}</h2>` : "";
-          const bio = item.bio ? `${item.bio}` : "";
-          const endNote = item.endNote ? `<p><em>${item.endNote}</em></p>` : "";
-          const byline = item.byline ? `<p>${byline}</p>` : "";
-          return `${title} ${byline} ${bio} ${htmlFromElements(item.content)} ${endNote}`
-      }
-
-      getTimelineEventContent(event, htmlFromElements){
-          const title = event.title ? `<h2>${event.title}</h2>` : "";
-          const date = event.date ? `<p>${event.date}</p>` : "";
-          return `${title} ${date} ${htmlFromElements(event.body)}`
-      }
-
       getHTMLContent(){
         var content = this.get('snapshot.preview').blocks.map((block) => block.elements);
         content = flatten(content);
@@ -71,7 +72,7 @@ SnapshotModelMod.factory('SnapshotModel', [
                 if (element.fields.sections) {
                     // This element is a Timeline element
                     return element.fields.sections.map((section) => {
-                        return `${section.title} ${section.events.map(event => getTimelineEventContent(body)).join('')}`
+                        return `${section.title} ${section.events.map(event => getTimelineEventContent(event, htmlFromElements)).join('')}`
                     }).join('');
                 }
             }).join('');

--- a/public/javascripts/app/models/SnapshotModel.js
+++ b/public/javascripts/app/models/SnapshotModel.js
@@ -37,6 +37,20 @@ SnapshotModelMod.factory('SnapshotModel', [
           return this.get("snapshot.preview.fields.trailText");
       }
 
+      getListItemContent(item, htmlFromElements) {
+          const title = item.title ? `<h2>${item.title}</h2>` : "";
+          const bio = item.bio ? `${item.bio}` : "";
+          const endNote = item.endNote ? `<p><em>${item.endNote}</em></p>` : "";
+          const byline = item.byline ? `<p>${byline}</p>` : "";
+          return `${title} ${byline} ${bio} ${htmlFromElements(item.content)} ${endNote}`
+      }
+
+      getTimelineEventContent(event, htmlFromElements){
+          const title = event.title ? `<h2>${event.title}</h2>` : "";
+          const date = event.date ? `<p>${event.date}</p>` : "";
+          return `${title} ${date} ${htmlFromElements(event.body)}`
+      }
+
       getHTMLContent(){
         var content = this.get('snapshot.preview').blocks.map((block) => block.elements);
         content = flatten(content);
@@ -49,8 +63,15 @@ SnapshotModelMod.factory('SnapshotModel', [
                     return element.fields.html;
                 }
                 if (element.fields.items) {
+                    // This element is a List element (Key takeaways, Q&A Explainer, Mini profiles)
                     return element.fields.items.map((item) => {
-                        return `<h2>${item.title}</h2>` + htmlFromElements(item.content)
+                        return getListItemContent(item, htmlFromElements)
+                    }).join('');
+                }
+                if (element.fields.sections) {
+                    // This element is a Timeline element
+                    return element.fields.sections.map((section) => {
+                        return `${section.title} ${section.events.map(event => getTimelineEventContent(body)).join('')}`
                     }).join('');
                 }
             }).join('');


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Render something for Timelines and Mini-profiles in Restorer, so as not to give the impression that they've not been saved.

| In Composer | In Restorer |
| --- | --- |
| Timeline: ![image](https://github.com/user-attachments/assets/ebd059c0-f886-48c9-9e2a-25ac2bf7fa82) | Timeline: ![image](https://github.com/user-attachments/assets/bdca32ab-8e07-407b-8d7d-e1f79fb43ecf) |
| Mini-profiles: ![image](https://github.com/user-attachments/assets/7766c18b-fdae-4c4e-8cc0-cdd2e337f229) | Mini-profiles: ![image](https://github.com/user-attachments/assets/40d4deb1-aeaa-4f7e-8cba-35f00e739ab9) |

## How to test

Deploy this branch to CODE. Check:
- Timeline: https://restorer.code.dev-gutools.co.uk/content/669793348f08862e0fe0b4c0/versions
- Mini-profiles: https://restorer.code.dev-gutools.co.uk/content/669789e58f08862e0fe0b4be/versions
- Key-takeaways: https://restorer.code.dev-gutools.co.uk/content/660fb5488f08e7615e8ee794/versions