### PR TITLE
Use correct byline after checking for truthiness

### DIFF
--- a/public/javascripts/app/models/SnapshotModel.js
+++ b/public/javascripts/app/models/SnapshotModel.js
@@ -11,7 +11,7 @@ const getListItemContent = (item, htmlFromElements) => {
     const title = item.title ? `<h2>${item.title}</h2>` : "";
     const bio = item.bio ? `${item.bio}` : "";
     const endNote = item.endNote ? `<p><em>${item.endNote}</em></p>` : "";
-    const byline = item.byline ? `<p>${byline}</p>` : "";
+    const byline = item.byline ? `<p>${item.byline}</p>` : "";
     return `${title} ${byline} ${bio} ${htmlFromElements(item.content)} ${endNote}`
 }
 


### PR DESCRIPTION
## What does this change?

Small typo in byline rendering.

If item.byline is undefined, this worked as expected. 
If item.byline is defined, byline is accessed before it is set.

Might fix a crash we are seeing