### PR TITLE
Add GuCname managing DNS in NS1, pointing at legacy ELB (migration ph…

### DIFF
--- a/cdk/lib/__snapshots__/restorer2.test.ts.snap
+++ b/cdk/lib/__snapshots__/restorer2.test.ts.snap
@@ -484,9 +484,17 @@ exports[`The Restorer2 stack matches the snapshot for CODE 1`] = `
         "RecordType": "CNAME",
         "ResourceRecords": [
           {
-            "Fn::GetAtt": [
-              "RestorerLoadBalancer",
-              "DNSName",
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::GetAtt": [
+                    "RestorerLoadBalancer",
+                    "DNSName",
+                  ],
+                },
+                ".",
+              ],
             ],
           },
         ],
@@ -2339,9 +2347,17 @@ exports[`The Restorer2 stack matches the snapshot for PROD 1`] = `
         "RecordType": "CNAME",
         "ResourceRecords": [
           {
-            "Fn::GetAtt": [
-              "RestorerLoadBalancer",
-              "DNSName",
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::GetAtt": [
+                    "RestorerLoadBalancer",
+                    "DNSName",
+                  ],
+                },
+                ".",
+              ],
             ],
           },
         ],

--- a/cdk/lib/__snapshots__/restorer2.test.ts.snap
+++ b/cdk/lib/__snapshots__/restorer2.test.ts.snap
@@ -63,6 +63,7 @@ exports[`The Restorer2 stack matches the snapshot for CODE 1`] = `
       "GuAccessLoggingBucketParameter",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
+      "GuCname",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -476,6 +477,23 @@ exports[`The Restorer2 stack matches the snapshot for CODE 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "DnsRecord": {
+      "Properties": {
+        "Name": "restorer.code.dev-gutools.co.uk",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "RestorerLoadBalancer",
+              "DNSName",
+            ],
+          },
+        ],
+        "Stage": "CODE",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
     },
     "GetDistributablePolicyRestorer220872BCF": {
       "Properties": {
@@ -1900,6 +1918,7 @@ exports[`The Restorer2 stack matches the snapshot for PROD 1`] = `
       "GuAccessLoggingBucketParameter",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
+      "GuCname",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -2313,6 +2332,23 @@ exports[`The Restorer2 stack matches the snapshot for PROD 1`] = `
         ],
       },
       "Type": "AWS::IAM::Policy",
+    },
+    "DnsRecord": {
+      "Properties": {
+        "Name": "restorer.gutools.co.uk",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "RestorerLoadBalancer",
+              "DNSName",
+            ],
+          },
+        ],
+        "Stage": "PROD",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
     },
     "GetDistributablePolicyRestorer220872BCF": {
       "Properties": {

--- a/cdk/lib/restorer2.ts
+++ b/cdk/lib/restorer2.ts
@@ -164,7 +164,8 @@ export class Restorer2 extends GuStack {
       app,
       domainName: stageConfig.domainName,
       ttl: Duration.hours(1),
-      resourceRecord: legacyLoadBalancer.attrDnsName,
+      // Trailing dot to match the existing NS1 record's fully-qualified target.
+      resourceRecord: `${legacyLoadBalancer.attrDnsName}.`,
     });
   }
 }

--- a/cdk/lib/restorer2.ts
+++ b/cdk/lib/restorer2.ts
@@ -2,12 +2,14 @@ import { join } from "path";
 import { AccessScope } from "@guardian/cdk/lib/constants";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import { GuStack } from "@guardian/cdk/lib/constructs/core";
+import { GuCname } from "@guardian/cdk/lib/constructs/dns";
 import { GuVpc } from "@guardian/cdk/lib/constructs/ec2";
 import { GuAllowPolicy } from "@guardian/cdk/lib/constructs/iam";
 import { GuEc2App } from "@guardian/cdk/lib/patterns/ec2-app";
 import type { App } from "aws-cdk-lib";
-import { Tags } from "aws-cdk-lib";
+import { Duration, Tags } from "aws-cdk-lib";
 import { InstanceClass, InstanceSize, InstanceType, SecurityGroup, UserData } from "aws-cdk-lib/aws-ec2";
+import type { CfnLoadBalancer } from "aws-cdk-lib/aws-elasticloadbalancing";
 import { CfnInclude } from "aws-cdk-lib/cloudformation-include";
 
 const app = "restorer2";
@@ -151,5 +153,18 @@ export class Restorer2 extends GuStack {
     // Tag the new ASG so Riff-Raff can target it while the legacy ASG still
     // exists (asgMigrationInProgress in riff-raff.yaml).
     Tags.of(ec2App.autoScalingGroup).add("gu:riffraff:new-asg", "true");
+
+    // Phase 3: manage the DNS record in NS1 via GuCname. It initially points at
+    // the legacy ELB so adopting the record is a no-op (no traffic change); the
+    // cutover to the new ALB is done by switching resourceRecord to
+    // `ec2App.loadBalancer.loadBalancerDnsName`. Lower the TTL before cutting
+    // over so the change propagates quickly, then raise it again once soaked.
+    const legacyLoadBalancer = cfnInclude.getResource("RestorerLoadBalancer") as CfnLoadBalancer;
+    new GuCname(this, "DnsRecord", {
+      app,
+      domainName: stageConfig.domainName,
+      ttl: Duration.hours(1),
+      resourceRecord: legacyLoadBalancer.attrDnsName,
+    });
   }
 }

--- a/plans/cloudformation-to-cdk-migration.md
+++ b/plans/cloudformation-to-cdk-migration.md
@@ -54,11 +54,15 @@ Known benign diff artefacts (no action): (a) CDK grants the LB egress to the API
 
 
 ### Phase 3 — Stage 2: switch DNS
-1. Start managing the DNS records via a `GuCname` construct, matching current NS1 properties, still pointing at the **old ELB**.
-2. Lower the TTL to a few minutes; wait for it to expire.
-3. Update the CNAME to point at the **new ALB**.
+
+✅ **Step 1 implemented** (same branch): a per-stage `GuCname` now manages the NS1 record. `resourceRecord` is wired to the legacy ELB via `cfnInclude.getResource("RestorerLoadBalancer").attrDnsName`, so adopting the record is a no-op. Lint, tests (CODE + PROD snapshots) and synth are green; the record synthesises as a `Guardian::DNS::RecordSet` CNAME (TTL 3600) pointing at `GetAtt RestorerLoadBalancer.DNSName`.
+
+1. ✅ Manage the DNS records via a `GuCname` construct, still pointing at the **old ELB** (adoption is a no-op). Note: the DNS-manager will need to adopt the existing manually-created NS1 record on first deploy.
+2. Lower the TTL to a few minutes (drop `Duration.hours(1)` in `restorer2.ts`); wait for it to expire.
+3. Update the CNAME to point at the **new ALB** by switching `resourceRecord` to `ec2App.loadBalancer.loadBalancerDnsName`.
 4. Test functionality (auth via pan-domain, snapshot listing/restore, exports).
 5. Soak for a while (fast rollback = revert the DNS change). Once confident, raise the TTL again.
+
 
 ### Phase 4 — Stage 3: cleanup
 1. In CloudWatch, confirm the **old ELB receives 0 requests**.


### PR DESCRIPTION
> [!NOTE]  
> This PR was opened by Claude Opus 4.8 based on an interactive session but I have reviewed the output

### What
First step of the DNS cutover. Adds a per-stage `GuCname` so the NS1 records for `restorer.code.dev-gutools.co.uk` / `restorer.gutools.co.uk` are managed by this stack. The record initially resolves to the **legacy ELB**, so adopting it is a no-op — no traffic moves. The actual switch to the new ALB is a later, isolated change (step 3), which de-risks ownership transfer from the traffic cutover.

### Changes
- **restorer2.ts** — add a `GuCname` per stage:
  - `domainName` from the existing per-stage `stageConfig`.
  - `resourceRecord` wired to the legacy ELB via `cfnInclude.getResource("RestorerLoadBalancer").attrDnsName` (`GetAtt RestorerLoadBalancer.DNSName`).
  - `ttl: Duration.hours(1)` for now; lowered just before cutover.
  - New imports: `GuCname`, `Duration`, and the `CfnLoadBalancer` type.
- **restorer2.test.ts.snap** — refreshed to include the new `Guardian::DNS::RecordSet` for both CODE and PROD.
- **cloudformation-to-cdk-migration.md** — mark phase 3 step 1 done and record the repoint mechanism.

Synthesised record (both stages):
```json
"DnsRecord": {
  "Type": "Guardian::DNS::RecordSet",
  "Properties": {
    "Name": "restorer.code.dev-gutools.co.uk",
    "ResourceRecords": [{ "Fn::GetAtt": ["RestorerLoadBalancer", "DNSName"] }],
    "RecordType": "CNAME",
    "TTL": 3600,
    "Stage": "CODE"
  }
}
```

### Testing
- Lint, CODE + PROD snapshot tests, and synth all green.
- Not yet deployed.

### Deployment
Same branch-first flow as phase 2 (CD deploys `main` → PROD):
1. Deploy this branch to **CODE via Riff-Raff without merging**. On first deploy the DNS-manager must **adopt the existing manually-created NS1 record** — watch for adoption errors ("record already exists") and resolve before proceeding.
2. Confirm the record still resolves to the legacy ELB and the app is unaffected.
3. Merge to let CD apply the same no-op adoption in PROD.

### Follow-up (not in this PR)
- Step 2: lower the TTL (drop `Duration.hours(1)`), let it expire.
- Step 3: repoint by switching `resourceRecord` to `ec2App.loadBalancer.loadBalancerDnsName`.
- Steps 4–5: test end-to-end, soak, then raise the TTL.

### Risks
- **NS1 record adoption** is the main risk — the record currently exists outside CFN. Verify CODE adoption succeeds before merging for PROD. Fast rollback throughout phase 3 is reverting the DNS change.