### PR TITLE
Repoint restorer DNS CNAME to the new ALB (migration phase 3, step 3)

### DIFF
--- a/cdk/lib/__snapshots__/restorer2.test.ts.snap
+++ b/cdk/lib/__snapshots__/restorer2.test.ts.snap
@@ -489,7 +489,7 @@ exports[`The Restorer2 stack matches the snapshot for CODE 1`] = `
               [
                 {
                   "Fn::GetAtt": [
-                    "RestorerLoadBalancer",
+                    "LoadBalancerRestorer2E6E71926",
                     "DNSName",
                   ],
                 },
@@ -2352,7 +2352,7 @@ exports[`The Restorer2 stack matches the snapshot for PROD 1`] = `
               [
                 {
                   "Fn::GetAtt": [
-                    "RestorerLoadBalancer",
+                    "LoadBalancerRestorer2E6E71926",
                     "DNSName",
                   ],
                 },

--- a/cdk/lib/restorer2.ts
+++ b/cdk/lib/restorer2.ts
@@ -9,7 +9,6 @@ import { GuEc2App } from "@guardian/cdk/lib/patterns/ec2-app";
 import type { App } from "aws-cdk-lib";
 import { Duration, Tags } from "aws-cdk-lib";
 import { InstanceClass, InstanceSize, InstanceType, SecurityGroup, UserData } from "aws-cdk-lib/aws-ec2";
-import type { CfnLoadBalancer } from "aws-cdk-lib/aws-elasticloadbalancing";
 import { CfnInclude } from "aws-cdk-lib/cloudformation-include";
 
 const app = "restorer2";
@@ -154,18 +153,16 @@ export class Restorer2 extends GuStack {
     // exists (asgMigrationInProgress in riff-raff.yaml).
     Tags.of(ec2App.autoScalingGroup).add("gu:riffraff:new-asg", "true");
 
-    // Phase 3: manage the DNS record in NS1 via GuCname. It initially points at
-    // the legacy ELB so adopting the record is a no-op (no traffic change); the
-    // cutover to the new ALB is done by switching resourceRecord to
-    // `ec2App.loadBalancer.loadBalancerDnsName`. TTL is lowered ahead of the
-    // cutover so the change propagates quickly; raise it again once soaked.
-    const legacyLoadBalancer = cfnInclude.getResource("RestorerLoadBalancer") as CfnLoadBalancer;
+    // Phase 3: manage the DNS record in NS1 via GuCname. It now points at the
+    // new ALB, cutting traffic over from the legacy ELB. TTL is kept low during
+    // the soak so rollback (repointing to the ELB) propagates quickly; raise it
+    // again once confident.
     new GuCname(this, "DnsRecord", {
       app,
       domainName: stageConfig.domainName,
       ttl: Duration.seconds(60),
-      // Trailing dot to match the existing NS1 record's fully-qualified target.
-      resourceRecord: `${legacyLoadBalancer.attrDnsName}.`,
+      // Trailing dot for a fully-qualified CNAME target.
+      resourceRecord: `${ec2App.loadBalancer.loadBalancerDnsName}.`,
     });
   }
 }

--- a/cdk/lib/restorer2.ts
+++ b/cdk/lib/restorer2.ts
@@ -161,7 +161,7 @@ export class Restorer2 extends GuStack {
       app,
       domainName: stageConfig.domainName,
       ttl: Duration.seconds(60),
-      // Trailing dot for a fully-qualified CNAME target.
+      // Trailing dot to match NS1 records fully-qualified format.
       resourceRecord: `${ec2App.loadBalancer.loadBalancerDnsName}.`,
     });
   }

--- a/plans/cloudformation-to-cdk-migration.md
+++ b/plans/cloudformation-to-cdk-migration.md
@@ -59,7 +59,7 @@ Known benign diff artefacts (no action): (a) CDK grants the LB egress to the API
 
 1. ✅ Manage the DNS records via a `GuCname` construct, still pointing at the **old ELB** (adoption is a no-op). Note: the DNS-manager will need to adopt the existing manually-created NS1 record on first deploy.
 2. ✅ Lowered the TTL to 60 seconds (`Duration.seconds(60)` in `restorer2.ts`). Deploy, then wait for the old TTL to expire before cutting over.
-3. Update the CNAME to point at the **new ALB** by switching `resourceRecord` to `ec2App.loadBalancer.loadBalancerDnsName`.
+3. ✅ Repointed the CNAME to the **new ALB** — `resourceRecord` now uses `ec2App.loadBalancer.loadBalancerDnsName` (with a trailing dot). This is the traffic cutover; the legacy ELB is no longer referenced.
 4. Test functionality (auth via pan-domain, snapshot listing/restore, exports).
 5. Soak for a while (fast rollback = revert the DNS change). Once confident, raise the TTL again.
 


### PR DESCRIPTION
> [!NOTE]  
> This PR was opened by Claude Opus 4.8 based on an interactive session but I have reviewed the output

### What
**The traffic cutover.** Repoints the `GuCname` from the legacy ELB to the new `GuEc2App` ALB. After this deploys and the 60s TTL expires, all traffic to `restorer.code.dev-gutools.co.uk` / `restorer.gutools.co.uk` flows through the new ALB → new ASG. The legacy ELB/ASG stay running (removed in phase 4) so rollback is just reverting this change.

### Changes
- **restorer2.ts** — `resourceRecord` now uses `` `${ec2App.loadBalancer.loadBalancerDnsName}.` `` (was the legacy ELB's `attrDnsName`). Removed the now-unused `legacyLoadBalancer` reference and the `CfnLoadBalancer` import.

### Testing
- Lint, CODE + PROD snapshot tests, and synth all green; the synthesised CNAME resolves to the ALB with a trailing dot.
- Tested new ALB by editing local `/etc/hosts`
- Verified that DNS TTL is 60s using `dig`

### Deployment
Same branch-first flow (CD deploys `main` → PROD). Step 2's 60s TTL must already be live so the cutover propagates fast:
1. Deploy this branch to **CODE via Riff-Raff without merging**.
2. Wait ~60s for the CNAME to propagate, then **test end-to-end on CODE**: pan-domain auth, snapshot listing/restore, exports. Confirm the new ALB is serving.
3. **Soak.** If anything is wrong, revert this commit (repoints to the ELB) — recovery within the 60s TTL.
4. Once confident on CODE, merge to cut PROD over via CD; repeat the checks and soak.

### Follow-up (not in this PR)
- Raise the TTL again once soaked (phase 3, step 5).
- Phase 4: remove the legacy ELB/ASG/launch config and related resources.

### Risks
- This is the user-facing switch. Mitigated by the 60s TTL (fast rollback) and by leaving the legacy stack intact. Verify CODE thoroughly before merging for PROD.