### PR TITLE
Link splash screen label to input with id/for attributes

### DIFF
--- a/public/javascripts/app/templates/splash-screen.html
+++ b/public/javascripts/app/templates/splash-screen.html
@@ -9,10 +9,12 @@
     <form novalidate name="search"
           class="splash-screen__container__form center"
           ng-submit="formCtrl.formSubmit(search)">
-      <label  class="splash-screen__container__form__label">
+            <label  class="splash-screen__container__form__label"
+              for="composer-url-input">
         Enter a composer url:
       </label>
       <input  class="splash-screen__container__form__input"
+              id="composer-url-input"
               type="text"
               ng-required="true"
               ng-model="search.query"/>


### PR DESCRIPTION
## What

Adds an `id="composer-url-input"` to the composer URL text input on the splash screen and a matching `for="composer-url-input"` on its `<label>`.

## Why

Associating the label with the input improves accessibility (screen readers announce the label when the input is focused) and lets users click the label to focus the field. And allows end to end tests to target the field based on it's label

## Testing
Tested locally and in CODE
