### PR TITLE
Use GuCDK policy constructs for restorer IAM policies

### DIFF
--- a/cdk/lib/__snapshots__/restorer2.test.ts.snap
+++ b/cdk/lib/__snapshots__/restorer2.test.ts.snap
@@ -5,13 +5,13 @@ exports[`The Restorer2 stack matches the snapshot for CODE 1`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuAllowPolicy",
+      "GuGetS3ObjectsPolicy",
+      "GuGetS3ObjectsPolicy",
+      "GuGetS3ObjectsPolicy",
       "GuAllowPolicy",
       "GuAllowPolicy",
       "GuAllowPolicy",
-      "GuAllowPolicy",
-      "GuAllowPolicy",
-      "GuAllowPolicy",
-      "GuAllowPolicy",
+      "GuPutCloudwatchMetricsPolicy",
       "GuVpcParameter",
       "GuSubnetListParameter",
       "GuSubnetListParameter",
@@ -377,6 +377,27 @@ exports[`The Restorer2 stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "GuPutCloudwatchMetricsPolicyC5BCE402": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuPutCloudwatchMetricsPolicyC5BCE402",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleRestorer2A97F6455",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "InstanceRoleRestorer2A97F6455": {
       "Properties": {
         "AssumeRolePolicyDocument": {
@@ -723,27 +744,6 @@ exports[`The Restorer2 stack matches the snapshot for CODE 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "RestorerCloudwatchPolicy45C49589": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "cloudwatch:*",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "RestorerCloudwatchPolicy45C49589",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleRestorer2A97F6455",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
     "RestorerGetDistributablesPolicy147D3507": {
       "Properties": {
         "PolicyDocument": {
@@ -751,7 +751,7 @@ exports[`The Restorer2 stack matches the snapshot for CODE 1`] = `
             {
               "Action": "s3:GetObject",
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::composer-dist/*",
+              "Resource": "arn:aws:s3:::composer-dist/flexible/CODE/restorer2/*",
             },
           ],
           "Version": "2012-10-17",
@@ -1076,13 +1076,13 @@ exports[`The Restorer2 stack matches the snapshot for PROD 1`] = `
   "Metadata": {
     "gu:cdk:constructs": [
       "GuAllowPolicy",
+      "GuGetS3ObjectsPolicy",
+      "GuGetS3ObjectsPolicy",
+      "GuGetS3ObjectsPolicy",
       "GuAllowPolicy",
       "GuAllowPolicy",
       "GuAllowPolicy",
-      "GuAllowPolicy",
-      "GuAllowPolicy",
-      "GuAllowPolicy",
-      "GuAllowPolicy",
+      "GuPutCloudwatchMetricsPolicy",
       "GuVpcParameter",
       "GuSubnetListParameter",
       "GuSubnetListParameter",
@@ -1440,6 +1440,27 @@ exports[`The Restorer2 stack matches the snapshot for PROD 1`] = `
           "Version": "2012-10-17",
         },
         "PolicyName": "GuLogShippingPolicy981BFE5A",
+        "Roles": [
+          {
+            "Ref": "InstanceRoleRestorer2A97F6455",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "GuPutCloudwatchMetricsPolicyC5BCE402": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": "cloudwatch:PutMetricData",
+              "Effect": "Allow",
+              "Resource": "*",
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "GuPutCloudwatchMetricsPolicyC5BCE402",
         "Roles": [
           {
             "Ref": "InstanceRoleRestorer2A97F6455",
@@ -1826,27 +1847,6 @@ exports[`The Restorer2 stack matches the snapshot for PROD 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
-    "RestorerCloudwatchPolicy45C49589": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": "cloudwatch:*",
-              "Effect": "Allow",
-              "Resource": "*",
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "RestorerCloudwatchPolicy45C49589",
-        "Roles": [
-          {
-            "Ref": "InstanceRoleRestorer2A97F6455",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
     "RestorerGetDistributablesPolicy147D3507": {
       "Properties": {
         "PolicyDocument": {
@@ -1854,7 +1854,7 @@ exports[`The Restorer2 stack matches the snapshot for PROD 1`] = `
             {
               "Action": "s3:GetObject",
               "Effect": "Allow",
-              "Resource": "arn:aws:s3:::composer-dist/*",
+              "Resource": "arn:aws:s3:::composer-dist/flexible/PROD/restorer2/*",
             },
           ],
           "Version": "2012-10-17",

--- a/cdk/lib/restorer2.ts
+++ b/cdk/lib/restorer2.ts
@@ -2,7 +2,11 @@ import { AccessScope } from "@guardian/cdk/lib/constants";
 import type { GuStackProps } from "@guardian/cdk/lib/constructs/core";
 import { GuStack } from "@guardian/cdk/lib/constructs/core";
 import { GuCname } from "@guardian/cdk/lib/constructs/dns";
-import { GuAllowPolicy } from "@guardian/cdk/lib/constructs/iam";
+import {
+  GuAllowPolicy,
+  GuGetS3ObjectsPolicy,
+  GuPutCloudwatchMetricsPolicy,
+} from "@guardian/cdk/lib/constructs/iam";
 import { GuEc2App } from "@guardian/cdk/lib/patterns/ec2-app";
 import type { App } from "aws-cdk-lib";
 import { CfnParameter, Duration } from "aws-cdk-lib";
@@ -66,17 +70,15 @@ export class Restorer2 extends GuStack {
         actions: ["ssm:GetParameters", "ssm:GetParametersByPath"],
         resources: [`arn:aws:ssm:*:*:parameter/flexible/restorer/${this.stage}*`],
       }),
-      new GuAllowPolicy(this, "RestorerGetDistributablesPolicy", {
-        actions: ["s3:GetObject"],
-        resources: ["arn:aws:s3:::composer-dist/*"],
+      new GuGetS3ObjectsPolicy(this, "RestorerGetDistributablesPolicy", {
+        bucketName: "composer-dist",
+        paths: [`flexible/${this.stage}/${app}/*`],
       }),
-      new GuAllowPolicy(this, "PanDomainPolicy", {
-        actions: ["s3:GetObject"],
-        resources: ["arn:aws:s3:::pan-domain-auth-settings/*"],
+      new GuGetS3ObjectsPolicy(this, "PanDomainPolicy", {
+        bucketName: "pan-domain-auth-settings",
       }),
-      new GuAllowPolicy(this, "PermissionsPolicy", {
-        actions: ["s3:GetObject"],
-        resources: ["arn:aws:s3:::permissions-cache/*"],
+      new GuGetS3ObjectsPolicy(this, "PermissionsPolicy", {
+        bucketName: "permissions-cache",
       }),
       new GuAllowPolicy(this, "RestorerSnapshotBucketListPolicy", {
         actions: ["s3:ListBucket"],
@@ -90,10 +92,7 @@ export class Restorer2 extends GuStack {
         actions: ["kms:Decrypt", "kms:DescribeKey"],
         resources: [kmsKeyArn],
       }),
-      new GuAllowPolicy(this, "RestorerCloudwatchPolicy", {
-        actions: ["cloudwatch:*"],
-        resources: ["*"],
-      }),
+      new GuPutCloudwatchMetricsPolicy(this),
     ];
 
     const ec2App = new GuEc2App(this, {


### PR DESCRIPTION
> [!NOTE]
> This PR was opened by Claude Opus 5 based on an interactive session but I have reviewed the output

### What

Follow-up tidy-up to the CDK migration. Several of the instance role's IAM policies were hand-rolled with `GuAllowPolicy` when GuCDK already ships purpose-built constructs for them.

- `RestorerGetDistributablesPolicy`, `PanDomainPolicy` and `PermissionsPolicy` now use `GuGetS3ObjectsPolicy`.
- `RestorerCloudwatchPolicy` is replaced by `GuPutCloudwatchMetricsPolicy`.

While swapping the distributables policy over, I also scoped it to the prefix the `userData` actually reads from (`flexible/<stage>/restorer2/*`) rather than the whole `composer-dist` bucket.

### Why

Less bespoke IAM to review and maintain, and two meaningful reductions in blast radius:

- **`cloudwatch:*` on `*` → `cloudwatch:PutMetricData` on `*`.** The old policy allowed deleting alarms, deleting dashboards, and disabling alarm actions across the whole account. Nothing in `app` references CloudWatch at all, and `PutMetricData` is the only action the AWS SDK dependency plausibly needs.
- **`composer-dist/*` → `composer-dist/flexible/<stage>/restorer2/*`.** `composer-dist` is a shared bucket, so the old policy let the restorer read every other app's artifacts.

### Policies deliberately left as `GuAllowPolicy`

- `RestorerSSMPolicy` — GuCDK's `GuParameterStoreReadPolicy` hardcodes `/STAGE/STACK/APP` paths, which doesn't match this app's `/flexible/restorer/STAGE` convention. (Note `GuEc2App` attaches that policy anyway, so the role carries both.)
- `RestorerSnapshotBucketListPolicy` — no GuCDK construct covers `s3:ListBucket`.
- `RestorerSnapshotBucketGetPolicy` — `GuGetS3ObjectsPolicy` takes a single `bucketName`, so covering both snapshot buckets would mean two separate policy resources.
- `KMSKeyPolicy` — no equivalent construct.

### Risks / things to check before merging

- **This is not a no-op diff.** The CloudWatch policy's logical ID changes (`RestorerCloudwatchPolicy45C49589` → `GuPutCloudwatchMetricsPolicyC5BCE402`), so CloudFormation will delete and recreate it. Fine for an `AWS::IAM::Policy`, but worth being aware of during the deploy.
- **Please sanity-check the two permission reductions above against CODE before promoting to PROD** — I inferred them from the app source and `userData` rather than from CloudTrail. If anything does call CloudWatch reads, `GuGetCloudwatchMetricsPolicy` is the drop-in addition.
- Snapshot updated via `npm run test -- -u`; diff is limited to the policies described here.